### PR TITLE
Add Chessboard typing and AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+This repository contains Python source code in the `src/` directory and tests in `tests/`.
+
+Development workflow:
+- Run `source setup.sh` before running tests.
+- Execute tests with `pytest -q`.
+
+Style guidelines:
+- Follow PEP 8 with a maximum line length of 88 characters.
+- Use type hints on all public functions and methods.
+- Keep code simple and prefer dataclasses for structured data.

--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -1,5 +1,6 @@
 """dh_workspace package initialization."""
 
 from .placeholder import greet
+from .chessboard import Chessboard
 
-__all__ = ["greet"]
+__all__ = ["greet", "Chessboard"]

--- a/src/dh_workspace/chessboard.py
+++ b/src/dh_workspace/chessboard.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass
+class Piece:
+    """Represents a chess piece and its color."""
+
+    piece: str
+    color: str
+
+
+class Chessboard:
+    """Class representing state of a chessboard."""
+
+    BOARD_SIZE = 8
+
+    def __init__(self) -> None:
+        """Initialize an empty chessboard."""
+        self._board: list[list[Optional[Piece]]] = [
+            [None for _ in range(self.BOARD_SIZE)] for _ in range(self.BOARD_SIZE)
+        ]
+
+    def _validate_position(self, row: int, col: int) -> None:
+        """Raise ``ValueError`` if ``row`` or ``col`` is outside the board."""
+        if not (0 <= row < self.BOARD_SIZE and 0 <= col < self.BOARD_SIZE):
+            raise ValueError("Position out of bounds")
+
+    def place_piece(self, row: int, col: int, piece: str, color: str) -> None:
+        """Place a piece at the given position."""
+        self._validate_position(row, col)
+        self._board[row][col] = Piece(piece, color)
+
+    def remove_piece(self, row: int, col: int) -> None:
+        """Remove any piece from the given position."""
+        self._validate_position(row, col)
+        self._board[row][col] = None
+
+    def get_piece(self, row: int, col: int) -> Optional[Tuple[str, str]]:
+        """Return the piece and color at the given position, or ``None`` if empty."""
+        self._validate_position(row, col)
+        data = self._board[row][col]
+        if data is None:
+            return None
+        return data.piece, data.color
+
+    def is_empty(self, row: int, col: int) -> bool:
+        """Return ``True`` if the square is empty."""
+        self._validate_position(row, col)
+        return self._board[row][col] is None

--- a/tests/test_chessboard.py
+++ b/tests/test_chessboard.py
@@ -1,0 +1,34 @@
+import pytest
+
+from dh_workspace import Chessboard
+
+
+def test_board_initially_empty():
+    board = Chessboard()
+    for row in range(board.BOARD_SIZE):
+        for col in range(board.BOARD_SIZE):
+            assert board.is_empty(row, col)
+            assert board.get_piece(row, col) is None
+
+
+def test_place_and_get_piece():
+    board = Chessboard()
+    board.place_piece(0, 0, "rook", "white")
+    assert not board.is_empty(0, 0)
+    assert board.get_piece(0, 0) == ("rook", "white")
+
+
+def test_remove_piece():
+    board = Chessboard()
+    board.place_piece(1, 1, "knight", "black")
+    board.remove_piece(1, 1)
+    assert board.is_empty(1, 1)
+    assert board.get_piece(1, 1) is None
+
+
+def test_invalid_position():
+    board = Chessboard()
+    with pytest.raises(ValueError):
+        board.place_piece(-1, 0, "bishop", "white")
+    with pytest.raises(ValueError):
+        board.get_piece(8, 0)


### PR DESCRIPTION
## Summary
- Add Chessboard class and use a `Piece` dataclass
- Add unit tests for the basic functionality 
- document project conventions in a root `AGENTS.md`

## Testing
- `source setup.sh`
- `pytest -q`