### PR TITLE
Add ChessPiece base class with Knight implementation

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -2,5 +2,6 @@
 
 from .placeholder import greet
 from .chessboard import Chessboard
+from .pieces import ChessPiece, Knight
 
-__all__ = ["greet", "Chessboard"]
+__all__ = ["greet", "Chessboard", "ChessPiece", "Knight"]

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+BOARD_SIZE = 8
+
+
+@dataclass
+class ChessPiece(ABC):
+    """Base class for chess pieces."""
+
+    color: str
+
+    @abstractmethod
+    def possible_moves(self, row: int, col: int) -> List[Tuple[int, int]]:
+        """Return a list of possible moves from ``row`` and ``col``."""
+
+    def _is_valid(self, row: int, col: int) -> bool:
+        """Return ``True`` if the position is on the board."""
+        return 0 <= row < BOARD_SIZE and 0 <= col < BOARD_SIZE
+
+
+@dataclass
+class Knight(ChessPiece):
+    """Concrete ``ChessPiece`` representing a knight."""
+
+    def possible_moves(self, row: int, col: int) -> List[Tuple[int, int]]:
+        deltas = [
+            (2, 1),
+            (1, 2),
+            (-1, 2),
+            (-2, 1),
+            (-2, -1),
+            (-1, -2),
+            (1, -2),
+            (2, -1),
+        ]
+        moves: List[Tuple[int, int]] = []
+        for dr, dc in deltas:
+            new_row = row + dr
+            new_col = col + dc
+            if self._is_valid(new_row, new_col):
+                moves.append((new_row, new_col))
+        return moves

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dh_workspace import ChessPiece, Knight
+
+
+def test_chesspiece_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        ChessPiece("white")
+
+
+def test_knight_moves_center() -> None:
+    knight = Knight("white")
+    moves = knight.possible_moves(4, 4)
+    assert len(moves) == 8
+    assert (6, 5) in moves
+    assert (2, 3) in moves
+
+
+def test_knight_moves_edge() -> None:
+    knight = Knight("black")
+    moves = knight.possible_moves(0, 0)
+    assert sorted(moves) == [(1, 2), (2, 1)]


### PR DESCRIPTION
## Summary
- create ChessPiece ABC with common board validation
- implement Knight piece with movement rules
- expose new classes in the package
- test Knight possible moves and abstract class behaviour

## Testing
- `source setup.sh`
- `pytest -q`