### PR TITLE
Implement package configuration and logging

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -3,5 +3,16 @@
 from .placeholder import greet
 from .chessboard import Chessboard
 from .pieces import ChessPiece, Knight
+from .config import CONFIG, Config, configure
+from .logger import logger
 
-__all__ = ["greet", "Chessboard", "ChessPiece", "Knight"]
+__all__ = [
+    "greet",
+    "Chessboard",
+    "ChessPiece",
+    "Knight",
+    "CONFIG",
+    "Config",
+    "configure",
+    "logger",
+]

--- a/src/dh_workspace/__main__.py
+++ b/src/dh_workspace/__main__.py
@@ -1,0 +1,25 @@
+import argparse
+import logging
+
+from . import Chessboard, Config, configure, logger
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="dh_workspace entry point")
+    parser.add_argument("--board-size", type=int, default=Config().board_size)
+    parser.add_argument(
+        "--log-level", default=logging.getLevelName(Config().log_level)
+    )
+    args = parser.parse_args()
+
+    level = getattr(logging, args.log_level.upper(), Config().log_level)
+    configure(Config(board_size=args.board_size, log_level=level))
+
+    logger.info("Configured board size: %s", args.board_size)
+    board = Chessboard()
+    logger.info("Created board with size %s", board.BOARD_SIZE)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/dh_workspace/chessboard.py
+++ b/src/dh_workspace/chessboard.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from .config import CONFIG
+from .logger import logger
+
 
 @dataclass
 class Piece:
@@ -13,10 +16,10 @@ class Piece:
 class Chessboard:
     """Class representing state of a chessboard."""
 
-    BOARD_SIZE = 8
-
     def __init__(self) -> None:
         """Initialize an empty chessboard."""
+        self.BOARD_SIZE = CONFIG.board_size
+        logger.debug("Initializing chessboard with size %s", self.BOARD_SIZE)
         self._board: list[list[Optional[Piece]]] = [
             [None for _ in range(self.BOARD_SIZE)] for _ in range(self.BOARD_SIZE)
         ]

--- a/src/dh_workspace/config.py
+++ b/src/dh_workspace/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import logging
+
+
+@dataclass
+class Config:
+    """Configuration for the package."""
+
+    board_size: int = 8
+    log_level: int = logging.INFO
+
+
+CONFIG = Config()
+
+def configure(config: Config) -> None:
+    """Set global configuration and update logger level."""
+    global CONFIG
+    CONFIG = config
+    from .logger import logger
+
+    logger.setLevel(config.log_level)
+

--- a/src/dh_workspace/logger.py
+++ b/src/dh_workspace/logger.py
@@ -1,0 +1,10 @@
+import logging
+
+logger = logging.getLogger("dh_workspace")
+_handler = logging.StreamHandler()
+_formatter = logging.Formatter("[%(levelname)s] %(message)s")
+_handler.setFormatter(_formatter)
+logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -4,8 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Tuple
 
-
-BOARD_SIZE = 8
+from .config import CONFIG
+from .logger import logger
 
 
 @dataclass
@@ -20,7 +20,8 @@ class ChessPiece(ABC):
 
     def _is_valid(self, row: int, col: int) -> bool:
         """Return ``True`` if the position is on the board."""
-        return 0 <= row < BOARD_SIZE and 0 <= col < BOARD_SIZE
+        size = CONFIG.board_size
+        return 0 <= row < size and 0 <= col < size
 
 
 @dataclass
@@ -43,5 +44,13 @@ class Knight(ChessPiece):
             new_row = row + dr
             new_col = col + dc
             if self._is_valid(new_row, new_col):
+                logger.debug(
+                    "Knight move valid from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    new_row,
+                    new_col,
+                )
                 moves.append((new_row, new_col))
         return moves
+


### PR DESCRIPTION
## Summary
- add a dataclass-based `Config` with board size and log level
- integrate global config and logger with chessboard and chess pieces
- expose config and logger from package init
- provide an entry point for configuring the package

## Testing
- `source setup.sh`
- `pytest -q`