### PR TITLE
Add PieceMove class and update Knight moves

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -2,7 +2,7 @@
 
 from .placeholder import greet
 from .chessboard import Chessboard
-from .pieces import ChessPiece, Knight
+from .pieces import ChessPiece, Knight, PieceMove
 from .config import CONFIG, Config, configure
 from .logger import logger
 
@@ -10,6 +10,7 @@ __all__ = [
     "greet",
     "Chessboard",
     "ChessPiece",
+    "PieceMove",
     "Knight",
     "CONFIG",
     "Config",

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Tuple
+
+
+@dataclass
+class PieceMove:
+    """Represents a potential move for a piece."""
+
+    start: Tuple[int, int]
+    end: Tuple[int, int]
+    captures: List[Tuple[int, int]] = field(default_factory=list)
 
 from .config import CONFIG
 from .logger import logger
@@ -15,7 +24,7 @@ class ChessPiece(ABC):
     color: str
 
     @abstractmethod
-    def possible_moves(self, row: int, col: int) -> List[Tuple[int, int]]:
+    def possible_moves(self, row: int, col: int) -> List[PieceMove]:
         """Return a list of possible moves from ``row`` and ``col``."""
 
     def _is_valid(self, row: int, col: int) -> bool:
@@ -28,7 +37,7 @@ class ChessPiece(ABC):
 class Knight(ChessPiece):
     """Concrete ``ChessPiece`` representing a knight."""
 
-    def possible_moves(self, row: int, col: int) -> List[Tuple[int, int]]:
+    def possible_moves(self, row: int, col: int) -> List[PieceMove]:
         deltas = [
             (2, 1),
             (1, 2),
@@ -39,7 +48,7 @@ class Knight(ChessPiece):
             (1, -2),
             (2, -1),
         ]
-        moves: List[Tuple[int, int]] = []
+        moves: List[PieceMove] = []
         for dr, dc in deltas:
             new_row = row + dr
             new_col = col + dc
@@ -51,6 +60,12 @@ class Knight(ChessPiece):
                     new_row,
                     new_col,
                 )
-                moves.append((new_row, new_col))
+            moves.append(
+                PieceMove(
+                    start=(row, col),
+                    end=(new_row, new_col),
+                    captures=[(new_row, new_col)],
+                )
+            )
         return moves
 

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dh_workspace import ChessPiece, Knight
+from dh_workspace import ChessPiece, Knight, PieceMove
 
 
 def test_chesspiece_is_abstract() -> None:
@@ -12,11 +12,15 @@ def test_knight_moves_center() -> None:
     knight = Knight("white")
     moves = knight.possible_moves(4, 4)
     assert len(moves) == 8
-    assert (6, 5) in moves
-    assert (2, 3) in moves
+    ends = [m.end for m in moves]
+    assert (6, 5) in ends
+    assert (2, 3) in ends
 
 
 def test_knight_moves_edge() -> None:
     knight = Knight("black")
     moves = knight.possible_moves(0, 0)
-    assert sorted(moves) == [(1, 2), (2, 1)]
+    assert len(moves) == 8
+    ends = {m.end for m in moves}
+    assert (1, 2) in ends
+    assert (-1, -2) in ends


### PR DESCRIPTION
## Summary
- implement `PieceMove` dataclass for describing start, end and captured squares
- update `ChessPiece` API to return a list of `PieceMove`
- change `Knight.possible_moves` to provide all theoretical moves regardless of board limits
- export `PieceMove` and adjust tests for new behaviour

## Testing
- `source setup.sh`
- `pytest -q`