### PR TITLE
Add Black formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@ This repository contains Python source code in the `src/` directory and tests in
 Development workflow:
 - Run `source setup.sh` before running tests.
 - Execute tests with `pytest -q`.
+- Format the code with `black .` before committing.
 
 Style guidelines:
 - Follow PEP 8 with a maximum line length of 88 characters.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ After running the script, tests can be executed with:
 ```bash
 pytest
 ```
+
+Format the code using [Black](https://black.readthedocs.io/) before committing:
+
+```bash
+black .
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ numpy = "*"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.black]
+line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 numpy
+black

--- a/src/dh_workspace/__main__.py
+++ b/src/dh_workspace/__main__.py
@@ -7,9 +7,7 @@ from . import Chessboard, Config, configure, logger
 def main() -> None:
     parser = argparse.ArgumentParser(description="dh_workspace entry point")
     parser.add_argument("--board-size", type=int, default=Config().board_size)
-    parser.add_argument(
-        "--log-level", default=logging.getLevelName(Config().log_level)
-    )
+    parser.add_argument("--log-level", default=logging.getLevelName(Config().log_level))
     args = parser.parse_args()
 
     level = getattr(logging, args.log_level.upper(), Config().log_level)
@@ -22,4 +20,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/dh_workspace/config.py
+++ b/src/dh_workspace/config.py
@@ -12,6 +12,7 @@ class Config:
 
 CONFIG = Config()
 
+
 def configure(config: Config) -> None:
     """Set global configuration and update logger level."""
     global CONFIG
@@ -19,4 +20,3 @@ def configure(config: Config) -> None:
     from .logger import logger
 
     logger.setLevel(config.log_level)
-

--- a/src/dh_workspace/logger.py
+++ b/src/dh_workspace/logger.py
@@ -7,4 +7,3 @@ _handler.setFormatter(_formatter)
 logger.addHandler(_handler)
 logger.setLevel(logging.INFO)
 logger.propagate = False
-

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -13,6 +13,7 @@ class PieceMove:
     end: Tuple[int, int]
     captures: List[Tuple[int, int]] = field(default_factory=list)
 
+
 from .config import CONFIG
 from .logger import logger
 
@@ -68,4 +69,3 @@ class Knight(ChessPiece):
                 )
             )
         return moves
-


### PR DESCRIPTION
## Summary
- format code with Black
- add Black to dependencies and configuration
- document formatting workflow in README and AGENTS

## Testing
- `pytest -q`
