### PR TITLE
Add PieceColor enum and Match class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@ Style guidelines:
 - Follow PEP 8 with a maximum line length of 88 characters.
 - Use type hints on all public functions and methods.
 - Keep code simple and prefer dataclasses for structured data.
+
+Gameplay utilities:
+- Use the `PieceColor` enum for piece colors.
+- Use the `Match` class to track matches with any number of players.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Format the code using [Black](https://black.readthedocs.io/) before committing:
 ```bash
 black .
 ```
+
+## Gameplay utilities
+
+`PieceColor` is an enum representing piece colors. The `Match` class can track a
+chess match for any number of players, storing the current turn, move number and
+captured pieces.

--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -2,7 +2,8 @@
 
 from .placeholder import greet
 from .chessboard import Chessboard
-from .pieces import ChessPiece, Knight, PieceMove
+from .pieces import ChessPiece, Knight, PieceMove, PieceColor
+from .match import Match
 from .config import CONFIG, Config, configure
 from .logger import logger
 
@@ -11,7 +12,9 @@ __all__ = [
     "Chessboard",
     "ChessPiece",
     "PieceMove",
+    "PieceColor",
     "Knight",
+    "Match",
     "CONFIG",
     "Config",
     "configure",

--- a/src/dh_workspace/chessboard.py
+++ b/src/dh_workspace/chessboard.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 
 from .config import CONFIG
 from .logger import logger
+from .pieces import PieceColor
 
 
 @dataclass
@@ -10,7 +11,7 @@ class Piece:
     """Represents a chess piece and its color."""
 
     piece: str
-    color: str
+    color: PieceColor
 
 
 class Chessboard:
@@ -29,7 +30,7 @@ class Chessboard:
         if not (0 <= row < self.BOARD_SIZE and 0 <= col < self.BOARD_SIZE):
             raise ValueError("Position out of bounds")
 
-    def place_piece(self, row: int, col: int, piece: str, color: str) -> None:
+    def place_piece(self, row: int, col: int, piece: str, color: PieceColor) -> None:
         """Place a piece at the given position."""
         self._validate_position(row, col)
         self._board[row][col] = Piece(piece, color)
@@ -39,7 +40,7 @@ class Chessboard:
         self._validate_position(row, col)
         self._board[row][col] = None
 
-    def get_piece(self, row: int, col: int) -> Optional[Tuple[str, str]]:
+    def get_piece(self, row: int, col: int) -> Optional[Tuple[str, PieceColor]]:
         """Return the piece and color at the given position, or ``None`` if empty."""
         self._validate_position(row, col)
         data = self._board[row][col]

--- a/src/dh_workspace/match.py
+++ b/src/dh_workspace/match.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .chessboard import Chessboard, Piece
+
+
+@dataclass
+class Match:
+    """Track the state of a chess match."""
+
+    board: Chessboard
+    num_players: int
+    current_turn: int = 0
+    move_number: int = 1
+    captured: List[List[Piece]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.captured = [[] for _ in range(self.num_players)]
+
+    def next_turn(self) -> None:
+        """Advance the match to the next player's turn."""
+        self.current_turn = (self.current_turn + 1) % self.num_players
+        self.move_number += 1
+
+    def capture_piece(self, player_index: int, piece: Piece) -> None:
+        """Record that ``piece`` was captured by ``player_index``."""
+        if not 0 <= player_index < self.num_players:
+            raise ValueError("Invalid player index")
+        self.captured[player_index].append(piece)

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import List, Tuple
 
 
@@ -18,11 +19,20 @@ from .config import CONFIG
 from .logger import logger
 
 
+class PieceColor(Enum):
+    """Enumeration of chess piece colors."""
+
+    WHITE = "white"
+    BLACK = "black"
+    RED = "red"
+    BLUE = "blue"
+
+
 @dataclass
 class ChessPiece(ABC):
     """Base class for chess pieces."""
 
-    color: str
+    color: PieceColor
 
     @abstractmethod
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:

--- a/tests/test_chessboard.py
+++ b/tests/test_chessboard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dh_workspace import Chessboard
+from dh_workspace import Chessboard, PieceColor
 
 
 def test_board_initially_empty():
@@ -13,14 +13,14 @@ def test_board_initially_empty():
 
 def test_place_and_get_piece():
     board = Chessboard()
-    board.place_piece(0, 0, "rook", "white")
+    board.place_piece(0, 0, "rook", PieceColor.WHITE)
     assert not board.is_empty(0, 0)
-    assert board.get_piece(0, 0) == ("rook", "white")
+    assert board.get_piece(0, 0) == ("rook", PieceColor.WHITE)
 
 
 def test_remove_piece():
     board = Chessboard()
-    board.place_piece(1, 1, "knight", "black")
+    board.place_piece(1, 1, "knight", PieceColor.BLACK)
     board.remove_piece(1, 1)
     assert board.is_empty(1, 1)
     assert board.get_piece(1, 1) is None
@@ -29,6 +29,6 @@ def test_remove_piece():
 def test_invalid_position():
     board = Chessboard()
     with pytest.raises(ValueError):
-        board.place_piece(-1, 0, "bishop", "white")
+        board.place_piece(-1, 0, "bishop", PieceColor.WHITE)
     with pytest.raises(ValueError):
         board.get_piece(8, 0)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,20 @@
+from dh_workspace import Chessboard, Match, PieceColor
+from dh_workspace.chessboard import Piece
+
+
+def test_match_initial_state():
+    match = Match(Chessboard(), num_players=3)
+    assert match.move_number == 1
+    assert match.current_turn == 0
+    assert len(match.captured) == 3
+    assert all(len(c) == 0 for c in match.captured)
+
+
+def test_match_turn_and_capture():
+    match = Match(Chessboard(), num_players=2)
+    piece = Piece("pawn", PieceColor.WHITE)
+    match.capture_piece(0, piece)
+    match.next_turn()
+    assert match.current_turn == 1
+    assert match.move_number == 2
+    assert match.captured[0][0] == piece

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -1,15 +1,15 @@
 import pytest
 
-from dh_workspace import ChessPiece, Knight, PieceMove
+from dh_workspace import ChessPiece, Knight, PieceMove, PieceColor
 
 
 def test_chesspiece_is_abstract() -> None:
     with pytest.raises(TypeError):
-        ChessPiece("white")
+        ChessPiece(PieceColor.WHITE)  # type: ignore
 
 
 def test_knight_moves_center() -> None:
-    knight = Knight("white")
+    knight = Knight(PieceColor.WHITE)
     moves = knight.possible_moves(4, 4)
     assert len(moves) == 8
     ends = [m.end for m in moves]
@@ -18,7 +18,7 @@ def test_knight_moves_center() -> None:
 
 
 def test_knight_moves_edge() -> None:
-    knight = Knight("black")
+    knight = Knight(PieceColor.BLACK)
     moves = knight.possible_moves(0, 0)
     assert len(moves) == 8
     ends = {m.end for m in moves}


### PR DESCRIPTION
## Summary
- add PieceColor enum for piece colors
- use PieceColor in Chessboard
- introduce Match class for tracking game state
- expose new types in package init
- document features in README and AGENTS
- expand tests for board, pieces, and new match class

## Testing
- `source setup.sh`
- `pytest -q`