### PR TITLE
Clean up import stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Format the code using [Black](https://black.readthedocs.io/) before committing:
 black .
 ```
 
-## Gameplay utilities
+## Directory structure
 
-`PieceColor` is an enum representing piece colors. The `Match` class can track a
-chess match for any number of players, storing the current turn, move number and
-captured pieces.
+The package code lives in `src/dh_workspace`. Game logic is implemented under
+`src/dh_workspace/core/` and supporting utilities are found in
+`src/dh_workspace/utils/`. Unit tests are located in the `tests/` directory.
+
+Module-level documentation describes the available classes and functions.

--- a/src/dh_workspace/chessboard.py
+++ b/src/dh_workspace/chessboard.py
@@ -1,1 +1,0 @@
-from .core.chessboard import *

--- a/src/dh_workspace/config.py
+++ b/src/dh_workspace/config.py
@@ -1,1 +1,0 @@
-from .utils.config import *

--- a/src/dh_workspace/logger.py
+++ b/src/dh_workspace/logger.py
@@ -1,1 +1,0 @@
-from .utils.logger import *

--- a/src/dh_workspace/match.py
+++ b/src/dh_workspace/match.py
@@ -1,1 +1,0 @@
-from .core.match import *

--- a/src/dh_workspace/pieces.py
+++ b/src/dh_workspace/pieces.py
@@ -1,1 +1,0 @@
-from .core.pieces import *

--- a/src/dh_workspace/placeholder.py
+++ b/src/dh_workspace/placeholder.py
@@ -1,1 +1,0 @@
-from .utils.placeholder import *

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,5 +1,5 @@
 from dh_workspace import Chessboard, Match, PieceColor
-from dh_workspace.chessboard import Piece
+from dh_workspace.core.chessboard import Piece
 
 
 def test_match_initial_state():


### PR DESCRIPTION
## Summary
- remove one-line wrappers that simply re-export modules
- adjust tests to import the real modules
- document the project layout in the README

## Testing
- `source setup.sh`
- `pytest -q`