### PR TITLE
Add pawn piece and board dimensions

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -2,7 +2,7 @@
 
 from .utils.placeholder import greet
 from .core.chessboard import Chessboard
-from .core.pieces import ChessPiece, Knight, PieceMove, PieceColor
+from .core.pieces import ChessPiece, Knight, Pawn, PieceMove, PieceColor
 from .core.match import Match
 from .utils.config import CONFIG, Config, configure
 from .utils.logger import logger
@@ -14,6 +14,7 @@ __all__ = [
     "PieceMove",
     "PieceColor",
     "Knight",
+    "Pawn",
     "Match",
     "CONFIG",
     "Config",

--- a/src/dh_workspace/__main__.py
+++ b/src/dh_workspace/__main__.py
@@ -6,16 +6,31 @@ from . import Chessboard, Config, configure, logger
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="dh_workspace entry point")
-    parser.add_argument("--board-size", type=int, default=Config().board_size)
+    parser.add_argument("--board-width", type=int, default=Config().board_width)
+    parser.add_argument("--board-height", type=int, default=Config().board_height)
     parser.add_argument("--log-level", default=logging.getLevelName(Config().log_level))
     args = parser.parse_args()
 
     level = getattr(logging, args.log_level.upper(), Config().log_level)
-    configure(Config(board_size=args.board_size, log_level=level))
+    configure(
+        Config(
+            board_width=args.board_width,
+            board_height=args.board_height,
+            log_level=level,
+        )
+    )
 
-    logger.info("Configured board size: %s", args.board_size)
+    logger.info(
+        "Configured board width %s height %s",
+        args.board_width,
+        args.board_height,
+    )
     board = Chessboard()
-    logger.info("Created board with size %s", board.BOARD_SIZE)
+    logger.info(
+        "Created board with width %s and height %s",
+        board.BOARD_WIDTH,
+        board.BOARD_HEIGHT,
+    )
 
 
 if __name__ == "__main__":

--- a/src/dh_workspace/core/chessboard.py
+++ b/src/dh_workspace/core/chessboard.py
@@ -19,15 +19,20 @@ class Chessboard:
 
     def __init__(self) -> None:
         """Initialize an empty chessboard."""
-        self.BOARD_SIZE = CONFIG.board_size
-        logger.debug("Initializing chessboard with size %s", self.BOARD_SIZE)
+        self.BOARD_WIDTH = CONFIG.board_width
+        self.BOARD_HEIGHT = CONFIG.board_height
+        logger.debug(
+            "Initializing chessboard with width %s and height %s",
+            self.BOARD_WIDTH,
+            self.BOARD_HEIGHT,
+        )
         self._board: list[list[Optional[Piece]]] = [
-            [None for _ in range(self.BOARD_SIZE)] for _ in range(self.BOARD_SIZE)
+            [None for _ in range(self.BOARD_WIDTH)] for _ in range(self.BOARD_HEIGHT)
         ]
 
     def _validate_position(self, row: int, col: int) -> None:
         """Raise ``ValueError`` if ``row`` or ``col`` is outside the board."""
-        if not (0 <= row < self.BOARD_SIZE and 0 <= col < self.BOARD_SIZE):
+        if not (0 <= row < self.BOARD_HEIGHT and 0 <= col < self.BOARD_WIDTH):
             raise ValueError("Position out of bounds")
 
     def place_piece(self, row: int, col: int, piece: str, color: PieceColor) -> None:

--- a/src/dh_workspace/core/pieces.py
+++ b/src/dh_workspace/core/pieces.py
@@ -40,8 +40,9 @@ class ChessPiece(ABC):
 
     def _is_valid(self, row: int, col: int) -> bool:
         """Return ``True`` if the position is on the board."""
-        size = CONFIG.board_size
-        return 0 <= row < size and 0 <= col < size
+        width = CONFIG.board_width
+        height = CONFIG.board_height
+        return 0 <= row < height and 0 <= col < width
 
 
 @dataclass
@@ -78,4 +79,41 @@ class Knight(ChessPiece):
                     captures=[(new_row, new_col)],
                 )
             )
+        return moves
+
+
+@dataclass
+class Pawn(ChessPiece):
+    """Concrete ``ChessPiece`` representing a pawn."""
+
+    def possible_moves(self, row: int, col: int) -> List[PieceMove]:
+        direction = -1 if self.color == PieceColor.WHITE else 1
+        new_row = row + direction
+        moves: List[PieceMove] = []
+        if self._is_valid(new_row, col):
+            logger.debug(
+                "Pawn move valid from (%s, %s) to (%s, %s)",
+                row,
+                col,
+                new_row,
+                col,
+            )
+            moves.append(PieceMove(start=(row, col), end=(new_row, col)))
+        for dc in (-1, 1):
+            new_col = col + dc
+            if self._is_valid(new_row, new_col):
+                logger.debug(
+                    "Pawn capture from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    new_row,
+                    new_col,
+                )
+                moves.append(
+                    PieceMove(
+                        start=(row, col),
+                        end=(new_row, new_col),
+                        captures=[(new_row, new_col)],
+                    )
+                )
         return moves

--- a/src/dh_workspace/utils/config.py
+++ b/src/dh_workspace/utils/config.py
@@ -6,7 +6,8 @@ import logging
 class Config:
     """Configuration for the package."""
 
-    board_size: int = 8
+    board_width: int = 8
+    board_height: int = 8
     log_level: int = logging.INFO
 
 

--- a/tests/test_chessboard.py
+++ b/tests/test_chessboard.py
@@ -5,8 +5,8 @@ from dh_workspace import Chessboard, PieceColor
 
 def test_board_initially_empty():
     board = Chessboard()
-    for row in range(board.BOARD_SIZE):
-        for col in range(board.BOARD_SIZE):
+    for row in range(board.BOARD_HEIGHT):
+        for col in range(board.BOARD_WIDTH):
             assert board.is_empty(row, col)
             assert board.get_piece(row, col) is None
 

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dh_workspace import ChessPiece, Knight, PieceMove, PieceColor
+from dh_workspace import ChessPiece, Knight, Pawn, PieceMove, PieceColor
 
 
 def test_chesspiece_is_abstract() -> None:
@@ -24,3 +24,12 @@ def test_knight_moves_edge() -> None:
     ends = {m.end for m in moves}
     assert (1, 2) in ends
     assert (-1, -2) in ends
+
+
+def test_pawn_moves() -> None:
+    pawn = Pawn(PieceColor.WHITE)
+    moves = pawn.possible_moves(4, 4)
+    ends = {m.end for m in moves}
+    assert (3, 4) in ends
+    assert (3, 3) in ends
+    assert (3, 5) in ends


### PR DESCRIPTION
## Summary
- implement pawn chess piece
- add board width and height config options
- update chessboard to support width/height
- expand CLI options for board dimensions
- adjust tests for new config and test pawn moves

## Testing
- `source setup.sh`
- `pytest -q`