### PR TITLE
Add Bishop piece

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -2,7 +2,7 @@
 
 from .utils.placeholder import greet
 from .core.chessboard import Chessboard
-from .core.pieces import ChessPiece, Knight, Pawn, PieceMove, PieceColor
+from .core.pieces import ChessPiece, Knight, Pawn, Bishop, PieceMove, PieceColor
 from .core.match import Match
 from .utils.config import CONFIG, Config, configure
 from .utils.logger import logger
@@ -15,6 +15,7 @@ __all__ = [
     "PieceColor",
     "Knight",
     "Pawn",
+    "Bishop",
     "Match",
     "CONFIG",
     "Config",

--- a/src/dh_workspace/core/pieces.py
+++ b/src/dh_workspace/core/pieces.py
@@ -144,3 +144,37 @@ class Pawn(ChessPiece):
                     )
                     moves.append(PieceMove(start=(row, col), end=(target_row, new_col)))
         return moves
+
+
+@dataclass
+class Bishop(ChessPiece):
+    """Concrete ``ChessPiece`` representing a bishop."""
+
+    def possible_moves(self, row: int, col: int) -> List[PieceMove]:
+        moves: List[PieceMove] = []
+        directions = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
+
+        for delta_row, delta_col in directions:
+            step = 1
+            while True:
+                new_row = row + delta_row * step
+                new_col = col + delta_col * step
+                if not self._is_valid(new_row, new_col):
+                    break
+
+                piece = self.board.get_piece(new_row, new_col)
+                if piece is None:
+                    moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+                else:
+                    if piece[1] != self.color:
+                        moves.append(
+                            PieceMove(
+                                start=(row, col),
+                                end=(new_row, new_col),
+                                captures=[(new_row, new_col)],
+                            )
+                        )
+                    break
+                step += 1
+
+        return moves

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dh_workspace import ChessPiece, Chessboard, Knight, Pawn, PieceColor
+from dh_workspace import ChessPiece, Chessboard, Knight, Pawn, Bishop, PieceColor
 
 
 def test_chesspiece_is_abstract() -> None:
@@ -57,3 +57,26 @@ def test_pawn_blocked() -> None:
     board.place_piece(3, 4, "pawn", PieceColor.WHITE)
     moves = pawn.possible_moves(4, 4)
     assert moves == []
+
+
+def test_bishop_moves_diagonally() -> None:
+    board = Chessboard()
+    bishop = Bishop(PieceColor.WHITE, board)
+    moves = bishop.possible_moves(4, 4)
+    assert len(moves) == 13
+    ends = {m.end for m in moves}
+    assert (0, 0) in ends
+    assert (7, 7) in ends
+    assert (3, 5) in ends
+
+
+def test_bishop_capture_and_block() -> None:
+    board = Chessboard()
+    bishop = Bishop(PieceColor.WHITE, board)
+    board.place_piece(6, 6, "pawn", PieceColor.BLACK)
+    board.place_piece(2, 2, "pawn", PieceColor.WHITE)
+    moves = bishop.possible_moves(4, 4)
+    ends = {m.end for m in moves}
+    assert (6, 6) in ends
+    assert (7, 7) not in ends
+    assert (2, 2) not in ends


### PR DESCRIPTION
## Summary
- implement Bishop chess piece with diagonal movement and capture rules
- expose Bishop in package exports
- test Bishop movement, capture, and blocking

## Testing
- `source setup.sh`
- `pytest -q`