### PR TITLE
Add queen piece and refactor move generation

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -8,6 +8,8 @@ from .core.pieces import (
     Pawn,
     Bishop,
     Rook,
+    Queen,
+    PieceType,
     PieceMove,
     PieceColor,
 )
@@ -25,6 +27,8 @@ __all__ = [
     "Pawn",
     "Bishop",
     "Rook",
+    "Queen",
+    "PieceType",
     "Match",
     "CONFIG",
     "Config",

--- a/src/dh_workspace/core/chessboard.py
+++ b/src/dh_workspace/core/chessboard.py
@@ -3,14 +3,14 @@ from typing import Optional, Tuple
 
 from ..utils.config import CONFIG
 from ..utils.logger import logger
-from .pieces import PieceColor
+from .pieces import PieceColor, PieceType
 
 
 @dataclass
 class Piece:
     """Represents a chess piece and its color."""
 
-    piece: str
+    piece: PieceType
     color: PieceColor
 
 
@@ -35,7 +35,9 @@ class Chessboard:
         if not (0 <= row < self.BOARD_HEIGHT and 0 <= col < self.BOARD_WIDTH):
             raise ValueError("Position out of bounds")
 
-    def place_piece(self, row: int, col: int, piece: str, color: PieceColor) -> None:
+    def place_piece(
+        self, row: int, col: int, piece: PieceType, color: PieceColor
+    ) -> None:
         """Place a piece at the given position."""
         self._validate_position(row, col)
         self._board[row][col] = Piece(piece, color)
@@ -45,7 +47,7 @@ class Chessboard:
         self._validate_position(row, col)
         self._board[row][col] = None
 
-    def get_piece(self, row: int, col: int) -> Optional[Tuple[str, PieceColor]]:
+    def get_piece(self, row: int, col: int) -> Optional[Tuple[PieceType, PieceColor]]:
         """Return the piece and color at the given position, or ``None`` if empty."""
         self._validate_position(row, col)
         data = self._board[row][col]

--- a/src/dh_workspace/core/pieces.py
+++ b/src/dh_workspace/core/pieces.py
@@ -33,6 +33,187 @@ class PieceColor(Enum):
     BLUE = "blue"
 
 
+class PieceType(Enum):
+    """Enumeration of chess piece identifiers."""
+
+    PAWN = "pawn"
+    KNIGHT = "knight"
+    BISHOP = "bishop"
+    ROOK = "rook"
+    QUEEN = "queen"
+
+
+def _is_valid(board: "Chessboard", row: int, col: int) -> bool:
+    """Return ``True`` if the position is on ``board``."""
+    return 0 <= row < board.BOARD_HEIGHT and 0 <= col < board.BOARD_WIDTH
+
+
+def generate_knight_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal knight moves from ``row`` and ``col``."""
+    deltas = [
+        (2, 1),
+        (1, 2),
+        (-1, 2),
+        (-2, 1),
+        (-2, -1),
+        (-1, -2),
+        (1, -2),
+        (2, -1),
+    ]
+    moves: List[PieceMove] = []
+    for delta_row, delta_col in deltas:
+        new_row = row + delta_row
+        new_col = col + delta_col
+        if not _is_valid(board, new_row, new_col):
+            continue
+
+        piece = board.get_piece(new_row, new_col)
+        if piece is None:
+            logger.debug(
+                "Knight move valid from (%s, %s) to (%s, %s)",
+                row,
+                col,
+                new_row,
+                new_col,
+            )
+            moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+        elif piece[1] != color:
+            logger.debug(
+                "Knight capture from (%s, %s) to (%s, %s)",
+                row,
+                col,
+                new_row,
+                new_col,
+            )
+            moves.append(
+                PieceMove(
+                    start=(row, col),
+                    end=(new_row, new_col),
+                    captures=[(new_row, new_col)],
+                )
+            )
+    return moves
+
+
+def generate_pawn_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal pawn moves from ``row`` and ``col``."""
+    direction = -1 if color == PieceColor.WHITE else 1
+    target_row = row + direction
+    candidate_moves = [(0, False), (-1, True), (1, True)]
+    moves: List[PieceMove] = []
+
+    for delta_col, is_capture in candidate_moves:
+        new_col = col + delta_col
+        if not _is_valid(board, target_row, new_col):
+            continue
+
+        piece = board.get_piece(target_row, new_col)
+        if is_capture:
+            if piece is not None and piece[1] != color:
+                logger.debug(
+                    "Pawn capture from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    target_row,
+                    new_col,
+                )
+                moves.append(
+                    PieceMove(
+                        start=(row, col),
+                        end=(target_row, new_col),
+                        captures=[(target_row, new_col)],
+                    )
+                )
+        else:
+            if piece is None:
+                logger.debug(
+                    "Pawn move valid from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    target_row,
+                    new_col,
+                )
+                moves.append(PieceMove(start=(row, col), end=(target_row, new_col)))
+    return moves
+
+
+def generate_bishop_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal bishop moves from ``row`` and ``col``."""
+    moves: List[PieceMove] = []
+    directions = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
+
+    for delta_row, delta_col in directions:
+        step = 1
+        while True:
+            new_row = row + delta_row * step
+            new_col = col + delta_col * step
+            if not _is_valid(board, new_row, new_col):
+                break
+
+            piece = board.get_piece(new_row, new_col)
+            if piece is None:
+                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+            else:
+                if piece[1] != color:
+                    moves.append(
+                        PieceMove(
+                            start=(row, col),
+                            end=(new_row, new_col),
+                            captures=[(new_row, new_col)],
+                        )
+                    )
+                break
+            step += 1
+    return moves
+
+
+def generate_rook_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal rook moves from ``row`` and ``col``."""
+    moves: List[PieceMove] = []
+    directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+
+    for delta_row, delta_col in directions:
+        step = 1
+        while True:
+            new_row = row + delta_row * step
+            new_col = col + delta_col * step
+            if not _is_valid(board, new_row, new_col):
+                break
+
+            piece = board.get_piece(new_row, new_col)
+            if piece is None:
+                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+            else:
+                if piece[1] != color:
+                    moves.append(
+                        PieceMove(
+                            start=(row, col),
+                            end=(new_row, new_col),
+                            captures=[(new_row, new_col)],
+                        )
+                    )
+                break
+            step += 1
+    return moves
+
+
+def generate_queen_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal queen moves from ``row`` and ``col``."""
+    return generate_rook_moves(board, color, row, col) + generate_bishop_moves(
+        board, color, row, col
+    )
+
+
 @dataclass
 class ChessPiece(ABC):
     """Base class for chess pieces."""
@@ -56,49 +237,7 @@ class Knight(ChessPiece):
     """Concrete ``ChessPiece`` representing a knight."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        deltas = [
-            (2, 1),
-            (1, 2),
-            (-1, 2),
-            (-2, 1),
-            (-2, -1),
-            (-1, -2),
-            (1, -2),
-            (2, -1),
-        ]
-        moves: List[PieceMove] = []
-        for delta_row, delta_col in deltas:
-            new_row = row + delta_row
-            new_col = col + delta_col
-            if not self._is_valid(new_row, new_col):
-                continue
-
-            piece = self.board.get_piece(new_row, new_col)
-            if piece is None:
-                logger.debug(
-                    "Knight move valid from (%s, %s) to (%s, %s)",
-                    row,
-                    col,
-                    new_row,
-                    new_col,
-                )
-                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-            elif piece[1] != self.color:
-                logger.debug(
-                    "Knight capture from (%s, %s) to (%s, %s)",
-                    row,
-                    col,
-                    new_row,
-                    new_col,
-                )
-                moves.append(
-                    PieceMove(
-                        start=(row, col),
-                        end=(new_row, new_col),
-                        captures=[(new_row, new_col)],
-                    )
-                )
-        return moves
+        return generate_knight_moves(self.board, self.color, row, col)
 
 
 @dataclass
@@ -106,44 +245,7 @@ class Pawn(ChessPiece):
     """Concrete ``ChessPiece`` representing a pawn."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        direction = -1 if self.color == PieceColor.WHITE else 1
-        target_row = row + direction
-        candidate_moves = [(0, False), (-1, True), (1, True)]
-        moves: List[PieceMove] = []
-
-        for delta_col, is_capture in candidate_moves:
-            new_col = col + delta_col
-            if not self._is_valid(target_row, new_col):
-                continue
-
-            piece = self.board.get_piece(target_row, new_col)
-            if is_capture:
-                if piece is not None and piece[1] != self.color:
-                    logger.debug(
-                        "Pawn capture from (%s, %s) to (%s, %s)",
-                        row,
-                        col,
-                        target_row,
-                        new_col,
-                    )
-                    moves.append(
-                        PieceMove(
-                            start=(row, col),
-                            end=(target_row, new_col),
-                            captures=[(target_row, new_col)],
-                        )
-                    )
-            else:
-                if piece is None:
-                    logger.debug(
-                        "Pawn move valid from (%s, %s) to (%s, %s)",
-                        row,
-                        col,
-                        target_row,
-                        new_col,
-                    )
-                    moves.append(PieceMove(start=(row, col), end=(target_row, new_col)))
-        return moves
+        return generate_pawn_moves(self.board, self.color, row, col)
 
 
 @dataclass
@@ -151,33 +253,7 @@ class Bishop(ChessPiece):
     """Concrete ``ChessPiece`` representing a bishop."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        moves: List[PieceMove] = []
-        directions = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
-
-        for delta_row, delta_col in directions:
-            step = 1
-            while True:
-                new_row = row + delta_row * step
-                new_col = col + delta_col * step
-                if not self._is_valid(new_row, new_col):
-                    break
-
-                piece = self.board.get_piece(new_row, new_col)
-                if piece is None:
-                    moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-                else:
-                    if piece[1] != self.color:
-                        moves.append(
-                            PieceMove(
-                                start=(row, col),
-                                end=(new_row, new_col),
-                                captures=[(new_row, new_col)],
-                            )
-                        )
-                    break
-                step += 1
-
-        return moves
+        return generate_bishop_moves(self.board, self.color, row, col)
 
 
 @dataclass
@@ -185,30 +261,12 @@ class Rook(ChessPiece):
     """Concrete ``ChessPiece`` representing a rook."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        moves: List[PieceMove] = []
-        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        return generate_rook_moves(self.board, self.color, row, col)
 
-        for delta_row, delta_col in directions:
-            step = 1
-            while True:
-                new_row = row + delta_row * step
-                new_col = col + delta_col * step
-                if not self._is_valid(new_row, new_col):
-                    break
 
-                piece = self.board.get_piece(new_row, new_col)
-                if piece is None:
-                    moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-                else:
-                    if piece[1] != self.color:
-                        moves.append(
-                            PieceMove(
-                                start=(row, col),
-                                end=(new_row, new_col),
-                                captures=[(new_row, new_col)],
-                            )
-                        )
-                    break
-                step += 1
+@dataclass
+class Queen(ChessPiece):
+    """Concrete ``ChessPiece`` representing a queen."""
 
-        return moves
+    def possible_moves(self, row: int, col: int) -> List[PieceMove]:
+        return generate_queen_moves(self.board, self.color, row, col)

--- a/tests/test_chessboard.py
+++ b/tests/test_chessboard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dh_workspace import Chessboard, PieceColor
+from dh_workspace import Chessboard, PieceColor, PieceType
 
 
 def test_board_initially_empty():
@@ -13,14 +13,14 @@ def test_board_initially_empty():
 
 def test_place_and_get_piece():
     board = Chessboard()
-    board.place_piece(0, 0, "rook", PieceColor.WHITE)
+    board.place_piece(0, 0, PieceType.ROOK, PieceColor.WHITE)
     assert not board.is_empty(0, 0)
-    assert board.get_piece(0, 0) == ("rook", PieceColor.WHITE)
+    assert board.get_piece(0, 0) == (PieceType.ROOK, PieceColor.WHITE)
 
 
 def test_remove_piece():
     board = Chessboard()
-    board.place_piece(1, 1, "knight", PieceColor.BLACK)
+    board.place_piece(1, 1, PieceType.KNIGHT, PieceColor.BLACK)
     board.remove_piece(1, 1)
     assert board.is_empty(1, 1)
     assert board.get_piece(1, 1) is None
@@ -29,6 +29,6 @@ def test_remove_piece():
 def test_invalid_position():
     board = Chessboard()
     with pytest.raises(ValueError):
-        board.place_piece(-1, 0, "bishop", PieceColor.WHITE)
+        board.place_piece(-1, 0, PieceType.BISHOP, PieceColor.WHITE)
     with pytest.raises(ValueError):
         board.get_piece(8, 0)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,4 +1,4 @@
-from dh_workspace import Chessboard, Match, PieceColor
+from dh_workspace import Chessboard, Match, PieceColor, PieceType
 from dh_workspace.core.chessboard import Piece
 
 
@@ -12,7 +12,7 @@ def test_match_initial_state():
 
 def test_match_turn_and_capture():
     match = Match(Chessboard(), num_players=2)
-    piece = Piece("pawn", PieceColor.WHITE)
+    piece = Piece(PieceType.PAWN, PieceColor.WHITE)
     match.capture_piece(0, piece)
     match.next_turn()
     assert match.current_turn == 1

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -7,7 +7,9 @@ from dh_workspace import (
     Pawn,
     Bishop,
     Rook,
+    Queen,
     PieceColor,
+    PieceType,
 )
 
 
@@ -30,8 +32,8 @@ def test_knight_moves_center() -> None:
 def test_knight_capture() -> None:
     board = Chessboard()
     knight = Knight(PieceColor.WHITE, board)
-    board.place_piece(5, 6, "pawn", PieceColor.BLACK)
-    board.place_piece(6, 5, "pawn", PieceColor.WHITE)
+    board.place_piece(5, 6, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(6, 5, PieceType.PAWN, PieceColor.WHITE)
     moves = knight.possible_moves(4, 4)
     ends = {m.end for m in moves}
     assert (6, 5) not in ends
@@ -50,7 +52,7 @@ def test_pawn_moves_forward() -> None:
 def test_pawn_capture() -> None:
     board = Chessboard()
     pawn = Pawn(PieceColor.WHITE, board)
-    board.place_piece(3, 3, "pawn", PieceColor.BLACK)
+    board.place_piece(3, 3, PieceType.PAWN, PieceColor.BLACK)
     moves = pawn.possible_moves(4, 4)
     ends = {m.end for m in moves}
     assert (3, 4) in ends
@@ -62,7 +64,7 @@ def test_pawn_capture() -> None:
 def test_pawn_blocked() -> None:
     board = Chessboard()
     pawn = Pawn(PieceColor.WHITE, board)
-    board.place_piece(3, 4, "pawn", PieceColor.WHITE)
+    board.place_piece(3, 4, PieceType.PAWN, PieceColor.WHITE)
     moves = pawn.possible_moves(4, 4)
     assert moves == []
 
@@ -81,8 +83,8 @@ def test_bishop_moves_diagonally() -> None:
 def test_bishop_capture_and_block() -> None:
     board = Chessboard()
     bishop = Bishop(PieceColor.WHITE, board)
-    board.place_piece(6, 6, "pawn", PieceColor.BLACK)
-    board.place_piece(2, 2, "pawn", PieceColor.WHITE)
+    board.place_piece(6, 6, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(2, 2, PieceType.PAWN, PieceColor.WHITE)
     moves = bishop.possible_moves(4, 4)
     ends = {m.end for m in moves}
     assert (6, 6) in ends
@@ -105,9 +107,9 @@ def test_rook_moves_straight() -> None:
 def test_rook_capture_and_block() -> None:
     board = Chessboard()
     rook = Rook(PieceColor.WHITE, board)
-    board.place_piece(4, 6, "pawn", PieceColor.BLACK)
-    board.place_piece(1, 4, "pawn", PieceColor.BLACK)
-    board.place_piece(4, 2, "pawn", PieceColor.WHITE)
+    board.place_piece(4, 6, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(1, 4, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(4, 2, PieceType.PAWN, PieceColor.WHITE)
     moves = rook.possible_moves(4, 4)
     ends = {m.end for m in moves}
     assert (4, 6) in ends
@@ -120,3 +122,36 @@ def test_rook_capture_and_block() -> None:
     capture2 = [m for m in moves if m.end == (1, 4)][0]
     assert capture1.captures == [(4, 6)]
     assert capture2.captures == [(1, 4)]
+
+
+def test_queen_moves_combined() -> None:
+    board = Chessboard()
+    queen = Queen(PieceColor.WHITE, board)
+    moves = queen.possible_moves(4, 4)
+    assert len(moves) == 27
+    ends = {m.end for m in moves}
+    assert (0, 4) in ends
+    assert (7, 7) in ends
+    assert (3, 5) in ends
+    assert (4, 0) in ends
+
+
+def test_queen_capture_and_block() -> None:
+    board = Chessboard()
+    queen = Queen(PieceColor.WHITE, board)
+    board.place_piece(4, 6, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(6, 6, PieceType.PAWN, PieceColor.BLACK)
+    board.place_piece(4, 2, PieceType.PAWN, PieceColor.WHITE)
+    board.place_piece(2, 2, PieceType.PAWN, PieceColor.WHITE)
+    moves = queen.possible_moves(4, 4)
+    ends = {m.end for m in moves}
+    assert (4, 6) in ends
+    assert (6, 6) in ends
+    assert (4, 7) not in ends
+    assert (7, 7) not in ends
+    assert (4, 2) not in ends
+    assert (2, 2) not in ends
+    capture1 = [m for m in moves if m.end == (4, 6)][0]
+    capture2 = [m for m in moves if m.end == (6, 6)][0]
+    assert capture1.captures == [(4, 6)]
+    assert capture2.captures == [(6, 6)]


### PR DESCRIPTION
## Summary
- introduce `PieceType` enum for chess piece identifiers
- create reusable move generation helpers for each piece
- implement queen piece using combined rook and bishop logic
- refactor piece classes to call the new helpers
- update chessboard to store `PieceType`
- expand tests to cover new functionality and enum usage

## Testing
- `source setup.sh`
- `pytest -q`