### PR TITLE
Centralize move generation

### DIFF
--- a/src/dh_workspace/core/moves.py
+++ b/src/dh_workspace/core/moves.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import List, Tuple, TYPE_CHECKING
+
+from .pieces import PieceMove, PieceColor, PieceType
+from ..utils.logger import logger
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from .chessboard import Chessboard
+
+
+def _is_valid(board: "Chessboard", row: int, col: int) -> bool:
+    """Return ``True`` if the position is on ``board``."""
+    return 0 <= row < board.BOARD_HEIGHT and 0 <= col < board.BOARD_WIDTH
+
+
+def generate_knight_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal knight moves from ``row`` and ``col``."""
+    deltas = [
+        (2, 1),
+        (1, 2),
+        (-1, 2),
+        (-2, 1),
+        (-2, -1),
+        (-1, -2),
+        (1, -2),
+        (2, -1),
+    ]
+    moves: List[PieceMove] = []
+    for delta_row, delta_col in deltas:
+        new_row = row + delta_row
+        new_col = col + delta_col
+        if not _is_valid(board, new_row, new_col):
+            continue
+
+        piece = board.get_piece(new_row, new_col)
+        if piece is None:
+            logger.debug(
+                "Knight move valid from (%s, %s) to (%s, %s)",
+                row,
+                col,
+                new_row,
+                new_col,
+            )
+            moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+        elif piece[1] != color:
+            logger.debug(
+                "Knight capture from (%s, %s) to (%s, %s)",
+                row,
+                col,
+                new_row,
+                new_col,
+            )
+            moves.append(
+                PieceMove(
+                    start=(row, col),
+                    end=(new_row, new_col),
+                    captures=[(new_row, new_col)],
+                )
+            )
+    return moves
+
+
+def generate_pawn_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal pawn moves from ``row`` and ``col``."""
+    direction = -1 if color == PieceColor.WHITE else 1
+    target_row = row + direction
+    candidate_moves = [(0, False), (-1, True), (1, True)]
+    moves: List[PieceMove] = []
+
+    for delta_col, is_capture in candidate_moves:
+        new_col = col + delta_col
+        if not _is_valid(board, target_row, new_col):
+            continue
+
+        piece = board.get_piece(target_row, new_col)
+        if is_capture:
+            if piece is not None and piece[1] != color:
+                logger.debug(
+                    "Pawn capture from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    target_row,
+                    new_col,
+                )
+                moves.append(
+                    PieceMove(
+                        start=(row, col),
+                        end=(target_row, new_col),
+                        captures=[(target_row, new_col)],
+                    )
+                )
+        else:
+            if piece is None:
+                logger.debug(
+                    "Pawn move valid from (%s, %s) to (%s, %s)",
+                    row,
+                    col,
+                    target_row,
+                    new_col,
+                )
+                moves.append(PieceMove(start=(row, col), end=(target_row, new_col)))
+    return moves
+
+
+def generate_bishop_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal bishop moves from ``row`` and ``col``."""
+    moves: List[PieceMove] = []
+    directions = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
+
+    for delta_row, delta_col in directions:
+        step = 1
+        while True:
+            new_row = row + delta_row * step
+            new_col = col + delta_col * step
+            if not _is_valid(board, new_row, new_col):
+                break
+
+            piece = board.get_piece(new_row, new_col)
+            if piece is None:
+                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+            else:
+                if piece[1] != color:
+                    moves.append(
+                        PieceMove(
+                            start=(row, col),
+                            end=(new_row, new_col),
+                            captures=[(new_row, new_col)],
+                        )
+                    )
+                break
+            step += 1
+    return moves
+
+
+def generate_rook_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal rook moves from ``row`` and ``col``."""
+    moves: List[PieceMove] = []
+    directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+
+    for delta_row, delta_col in directions:
+        step = 1
+        while True:
+            new_row = row + delta_row * step
+            new_col = col + delta_col * step
+            if not _is_valid(board, new_row, new_col):
+                break
+
+            piece = board.get_piece(new_row, new_col)
+            if piece is None:
+                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
+            else:
+                if piece[1] != color:
+                    moves.append(
+                        PieceMove(
+                            start=(row, col),
+                            end=(new_row, new_col),
+                            captures=[(new_row, new_col)],
+                        )
+                    )
+                break
+            step += 1
+    return moves
+
+
+def generate_queen_moves(
+    board: "Chessboard", color: PieceColor, row: int, col: int
+) -> List[PieceMove]:
+    """Return all legal queen moves from ``row`` and ``col``."""
+    return generate_rook_moves(board, color, row, col) + generate_bishop_moves(
+        board, color, row, col
+    )
+
+
+def generate_moves(
+    piece: PieceType,
+    board: "Chessboard",
+    color: PieceColor,
+    row: int,
+    col: int,
+) -> List[PieceMove]:
+    """Return the legal moves for ``piece`` at ``row`` and ``col``."""
+    if piece == PieceType.KNIGHT:
+        return generate_knight_moves(board, color, row, col)
+    if piece == PieceType.PAWN:
+        return generate_pawn_moves(board, color, row, col)
+    if piece == PieceType.BISHOP:
+        return generate_bishop_moves(board, color, row, col)
+    if piece == PieceType.ROOK:
+        return generate_rook_moves(board, color, row, col)
+    if piece == PieceType.QUEEN:
+        return generate_queen_moves(board, color, row, col)
+    raise ValueError(f"Unsupported piece type: {piece}")

--- a/src/dh_workspace/core/pieces.py
+++ b/src/dh_workspace/core/pieces.py
@@ -18,7 +18,7 @@ class PieceMove:
 from typing import TYPE_CHECKING
 
 from ..utils.config import CONFIG
-from ..utils.logger import logger
+
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .chessboard import Chessboard
@@ -43,175 +43,7 @@ class PieceType(Enum):
     QUEEN = "queen"
 
 
-def _is_valid(board: "Chessboard", row: int, col: int) -> bool:
-    """Return ``True`` if the position is on ``board``."""
-    return 0 <= row < board.BOARD_HEIGHT and 0 <= col < board.BOARD_WIDTH
-
-
-def generate_knight_moves(
-    board: "Chessboard", color: PieceColor, row: int, col: int
-) -> List[PieceMove]:
-    """Return all legal knight moves from ``row`` and ``col``."""
-    deltas = [
-        (2, 1),
-        (1, 2),
-        (-1, 2),
-        (-2, 1),
-        (-2, -1),
-        (-1, -2),
-        (1, -2),
-        (2, -1),
-    ]
-    moves: List[PieceMove] = []
-    for delta_row, delta_col in deltas:
-        new_row = row + delta_row
-        new_col = col + delta_col
-        if not _is_valid(board, new_row, new_col):
-            continue
-
-        piece = board.get_piece(new_row, new_col)
-        if piece is None:
-            logger.debug(
-                "Knight move valid from (%s, %s) to (%s, %s)",
-                row,
-                col,
-                new_row,
-                new_col,
-            )
-            moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-        elif piece[1] != color:
-            logger.debug(
-                "Knight capture from (%s, %s) to (%s, %s)",
-                row,
-                col,
-                new_row,
-                new_col,
-            )
-            moves.append(
-                PieceMove(
-                    start=(row, col),
-                    end=(new_row, new_col),
-                    captures=[(new_row, new_col)],
-                )
-            )
-    return moves
-
-
-def generate_pawn_moves(
-    board: "Chessboard", color: PieceColor, row: int, col: int
-) -> List[PieceMove]:
-    """Return all legal pawn moves from ``row`` and ``col``."""
-    direction = -1 if color == PieceColor.WHITE else 1
-    target_row = row + direction
-    candidate_moves = [(0, False), (-1, True), (1, True)]
-    moves: List[PieceMove] = []
-
-    for delta_col, is_capture in candidate_moves:
-        new_col = col + delta_col
-        if not _is_valid(board, target_row, new_col):
-            continue
-
-        piece = board.get_piece(target_row, new_col)
-        if is_capture:
-            if piece is not None and piece[1] != color:
-                logger.debug(
-                    "Pawn capture from (%s, %s) to (%s, %s)",
-                    row,
-                    col,
-                    target_row,
-                    new_col,
-                )
-                moves.append(
-                    PieceMove(
-                        start=(row, col),
-                        end=(target_row, new_col),
-                        captures=[(target_row, new_col)],
-                    )
-                )
-        else:
-            if piece is None:
-                logger.debug(
-                    "Pawn move valid from (%s, %s) to (%s, %s)",
-                    row,
-                    col,
-                    target_row,
-                    new_col,
-                )
-                moves.append(PieceMove(start=(row, col), end=(target_row, new_col)))
-    return moves
-
-
-def generate_bishop_moves(
-    board: "Chessboard", color: PieceColor, row: int, col: int
-) -> List[PieceMove]:
-    """Return all legal bishop moves from ``row`` and ``col``."""
-    moves: List[PieceMove] = []
-    directions = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
-
-    for delta_row, delta_col in directions:
-        step = 1
-        while True:
-            new_row = row + delta_row * step
-            new_col = col + delta_col * step
-            if not _is_valid(board, new_row, new_col):
-                break
-
-            piece = board.get_piece(new_row, new_col)
-            if piece is None:
-                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-            else:
-                if piece[1] != color:
-                    moves.append(
-                        PieceMove(
-                            start=(row, col),
-                            end=(new_row, new_col),
-                            captures=[(new_row, new_col)],
-                        )
-                    )
-                break
-            step += 1
-    return moves
-
-
-def generate_rook_moves(
-    board: "Chessboard", color: PieceColor, row: int, col: int
-) -> List[PieceMove]:
-    """Return all legal rook moves from ``row`` and ``col``."""
-    moves: List[PieceMove] = []
-    directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
-
-    for delta_row, delta_col in directions:
-        step = 1
-        while True:
-            new_row = row + delta_row * step
-            new_col = col + delta_col * step
-            if not _is_valid(board, new_row, new_col):
-                break
-
-            piece = board.get_piece(new_row, new_col)
-            if piece is None:
-                moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-            else:
-                if piece[1] != color:
-                    moves.append(
-                        PieceMove(
-                            start=(row, col),
-                            end=(new_row, new_col),
-                            captures=[(new_row, new_col)],
-                        )
-                    )
-                break
-            step += 1
-    return moves
-
-
-def generate_queen_moves(
-    board: "Chessboard", color: PieceColor, row: int, col: int
-) -> List[PieceMove]:
-    """Return all legal queen moves from ``row`` and ``col``."""
-    return generate_rook_moves(board, color, row, col) + generate_bishop_moves(
-        board, color, row, col
-    )
+from .moves import generate_moves
 
 
 @dataclass
@@ -237,7 +69,7 @@ class Knight(ChessPiece):
     """Concrete ``ChessPiece`` representing a knight."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        return generate_knight_moves(self.board, self.color, row, col)
+        return generate_moves(PieceType.KNIGHT, self.board, self.color, row, col)
 
 
 @dataclass
@@ -245,7 +77,7 @@ class Pawn(ChessPiece):
     """Concrete ``ChessPiece`` representing a pawn."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        return generate_pawn_moves(self.board, self.color, row, col)
+        return generate_moves(PieceType.PAWN, self.board, self.color, row, col)
 
 
 @dataclass
@@ -253,7 +85,7 @@ class Bishop(ChessPiece):
     """Concrete ``ChessPiece`` representing a bishop."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        return generate_bishop_moves(self.board, self.color, row, col)
+        return generate_moves(PieceType.BISHOP, self.board, self.color, row, col)
 
 
 @dataclass
@@ -261,7 +93,7 @@ class Rook(ChessPiece):
     """Concrete ``ChessPiece`` representing a rook."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        return generate_rook_moves(self.board, self.color, row, col)
+        return generate_moves(PieceType.ROOK, self.board, self.color, row, col)
 
 
 @dataclass
@@ -269,4 +101,4 @@ class Queen(ChessPiece):
     """Concrete ``ChessPiece`` representing a queen."""
 
     def possible_moves(self, row: int, col: int) -> List[PieceMove]:
-        return generate_queen_moves(self.board, self.color, row, col)
+        return generate_moves(PieceType.QUEEN, self.board, self.color, row, col)


### PR DESCRIPTION
## Summary
- move move-generating helpers to `moves.py`
- add a `generate_moves` factory to dispatch by piece type
- update chess piece classes to use the factory

## Testing
- `source setup.sh`
- `pytest -q`