### PR TITLE
Add gitignore and remove placeholder modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+
+# macOS
+.DS_Store

--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -1,6 +1,5 @@
 """dh_workspace package initialization."""
 
-from .utils.placeholder import greet
 from .core.chessboard import Chessboard
 from .core.pieces import (
     ChessPiece,
@@ -18,7 +17,6 @@ from .utils.config import CONFIG, Config, configure
 from .utils.logger import logger
 
 __all__ = [
-    "greet",
     "Chessboard",
     "ChessPiece",
     "PieceMove",

--- a/src/dh_workspace/utils/__init__.py
+++ b/src/dh_workspace/utils/__init__.py
@@ -1,11 +1,9 @@
 from .config import CONFIG, Config, configure
 from .logger import logger
-from .placeholder import greet
 
 __all__ = [
     "CONFIG",
     "Config",
     "configure",
     "logger",
-    "greet",
 ]

--- a/src/dh_workspace/utils/placeholder.py
+++ b/src/dh_workspace/utils/placeholder.py
@@ -1,6 +1,0 @@
-"""Placeholder module for the dh_workspace package."""
-
-
-def greet(name: str = "World") -> str:
-    """Return a greeting message."""
-    return f"Hello, {name}!"

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,5 +1,0 @@
-from dh_workspace import greet
-
-
-def test_greet_default():
-    assert greet() == "Hello, World!"


### PR DESCRIPTION
## Summary
- add Python-friendly `.gitignore`
- remove the `placeholder` utility module and associated test
- clean up `__init__` exports now that the placeholder is gone

## Testing
- `source setup.sh`
- `pytest -q`
