### PR TITLE
Add board coordinates and inverted view

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -16,7 +16,12 @@ from .core.backend.pieces import (
 from .core.backend.match import Match
 from .utils.config import CONFIG, Config, configure
 from .utils.logger import logger
-from .frontend.unicode_board import draw_board, draw_empty_board, save_board
+from .frontend.unicode_board import (
+    draw_board,
+    draw_board_inverted,
+    draw_empty_board,
+    save_board,
+)
 
 __all__ = [
     "Chessboard",
@@ -37,5 +42,6 @@ __all__ = [
     "logger",
     "draw_empty_board",
     "draw_board",
+    "draw_board_inverted",
     "save_board",
 ]

--- a/src/dh_workspace/frontend/unicode_board.py
+++ b/src/dh_workspace/frontend/unicode_board.py
@@ -11,8 +11,24 @@ _H_SEG = "━" * 3
 _EMPTY_CELL = " " * 3
 
 
-def draw_empty_board(width: int | None = None, height: int | None = None) -> str:
-    """Return a Unicode board with empty squares."""
+def draw_empty_board(
+    width: int | None = None,
+    height: int | None = None,
+    *,
+    with_coords: bool = False,
+) -> str:
+    """Return a Unicode board with empty squares.
+
+    Parameters
+    ----------
+    width:
+        Optional board width. Defaults to ``CONFIG.board_width``.
+    height:
+        Optional board height. Defaults to ``CONFIG.board_height``.
+    with_coords:
+        If ``True``, include numeric coordinates along the left and bottom
+        edges of the board.
+    """
 
     w = width or CONFIG.board_width
     h = height or CONFIG.board_height
@@ -21,17 +37,37 @@ def draw_empty_board(width: int | None = None, height: int | None = None) -> str
     mid = "┣" + "╋".join(_H_SEG for _ in range(w)) + "┫"
     bottom = "┗" + "┻".join(_H_SEG for _ in range(w)) + "┛"
 
-    lines = [top]
+    lines: list[str] = [top if not with_coords else f"  {top}"]
     for row in range(h):
-        lines.append("┃" + "┃".join(_EMPTY_CELL for _ in range(w)) + "┃")
+        row_line = "┃" + "┃".join(_EMPTY_CELL for _ in range(w)) + "┃"
+        if with_coords:
+            lines.append(f"{row + 1} {row_line}")
+        else:
+            lines.append(row_line)
         if row < h - 1:
-            lines.append(mid)
-    lines.append(bottom)
-    return "\n".join(lines)
+            lines.append(mid if not with_coords else f"  {mid}")
+    lines.append(bottom if not with_coords else f"  {bottom}")
+    if with_coords:
+        lines.append("  " + "   ".join(str(i + 1) for i in range(w)))
+    return "\n".join(lines) + "\n"
 
 
-def draw_board(board: "Chessboard") -> str:
-    """Return a Unicode chessboard containing the pieces from ``board``."""
+def draw_board(
+    board: "Chessboard", *, with_coords: bool = False, invert: bool = False
+) -> str:
+    """Return a Unicode chessboard containing the pieces from ``board``.
+
+    Parameters
+    ----------
+    board:
+        The ``Chessboard`` instance to render.
+    with_coords:
+        If ``True``, include numeric coordinates along the left and bottom
+        edges of the board.
+    invert:
+        If ``True``, draw the board upside down. Useful when switching the
+        player's perspective.
+    """
 
     from ..core.backend.pieces import PieceColor, PieceType
 
@@ -61,10 +97,13 @@ def draw_board(board: "Chessboard") -> str:
     mid = "┣" + "╋".join(_H_SEG for _ in range(w)) + "┫"
     bottom = "┗" + "┻".join(_H_SEG for _ in range(w)) + "┛"
 
-    lines = [top]
-    for row in range(h):
+    row_range = range(h - 1, -1, -1) if invert else range(h)
+    col_range = range(w - 1, -1, -1) if invert else range(w)
+
+    lines: list[str] = [top if not with_coords else f"  {top}"]
+    for idx, row in enumerate(row_range):
         cells = []
-        for col in range(w):
+        for col in col_range:
             piece = board.get_piece(row, col)
             if piece is None:
                 cells.append(_EMPTY_CELL)
@@ -72,11 +111,23 @@ def draw_board(board: "Chessboard") -> str:
                 p_type, p_color = piece
                 char = unicode_map.get(p_color, {}).get(p_type, "?")
                 cells.append(f" {char} ")
-        lines.append("┃" + "┃".join(cells) + "┃")
-        if row < h - 1:
-            lines.append(mid)
-    lines.append(bottom)
-    return "\n".join(lines)
+        row_line = "┃" + "┃".join(cells) + "┃"
+        if with_coords:
+            lines.append(f"{idx + 1} {row_line}")
+        else:
+            lines.append(row_line)
+        if idx < h - 1:
+            lines.append(mid if not with_coords else f"  {mid}")
+    lines.append(bottom if not with_coords else f"  {bottom}")
+    if with_coords:
+        lines.append("  " + "   ".join(str(i + 1) for i in range(w)))
+    return "\n".join(lines) + "\n"
+
+
+def draw_board_inverted(board: "Chessboard", *, with_coords: bool = False) -> str:
+    """Return ``board`` drawn upside down."""
+
+    return draw_board(board, with_coords=with_coords, invert=True)
 
 
 def save_board(text: str, path: str | Path) -> None:

--- a/tests/frontend/test_unicode_board.py
+++ b/tests/frontend/test_unicode_board.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from dh_workspace import Chessboard, Match, draw_board, draw_empty_board, save_board
+from dh_workspace import (
+    Chessboard,
+    Match,
+    draw_board,
+    draw_board_inverted,
+    draw_empty_board,
+    save_board,
+)
 
 
 def test_draw_empty_board_saves_file() -> None:
@@ -30,7 +37,7 @@ def test_draw_starting_board_saves_file() -> None:
 def test_unicode_board_structure() -> None:
     """Verify that ``draw_empty_board`` uses box drawing characters."""
 
-    expected = "┏━━━┳━━━┓\n" "┃   ┃   ┃\n" "┣━━━╋━━━┫\n" "┃   ┃   ┃\n" "┗━━━┻━━━┛"
+    expected = "┏━━━┳━━━┓\n" "┃   ┃   ┃\n" "┣━━━╋━━━┫\n" "┃   ┃   ┃\n" "┗━━━┻━━━┛\n"
     assert draw_empty_board(width=2, height=2) == expected
 
 
@@ -52,3 +59,27 @@ def test_board_after_pawn_and_knight_moves() -> None:
     if not output_file.exists():
         save_board(board_text, output_file)
     assert output_file.read_text() == board_text
+
+
+def test_draw_empty_board_with_coords() -> None:
+    """Ensure coordinates are added when requested."""
+
+    expected = (
+        "  ┏━━━┳━━━┓\n"
+        "1 ┃   ┃   ┃\n"
+        "  ┣━━━╋━━━┫\n"
+        "2 ┃   ┃   ┃\n"
+        "  ┗━━━┻━━━┛\n"
+        "  1   2\n"
+    )
+    assert draw_empty_board(width=2, height=2, with_coords=True) == expected
+
+
+def test_draw_board_inverted() -> None:
+    """The inverted board should show white pieces at the top."""
+
+    board = Chessboard()
+    board.reset_board()
+    top_row = draw_board_inverted(board).splitlines()[1]
+    assert "♖" in top_row
+    assert "♜" not in top_row


### PR DESCRIPTION
## Summary
- add optional coordinate labels when drawing boards
- support drawing boards upside down
- expose `draw_board_inverted`
- test new coordinate and inverted board features

## Testing
- `source setup.sh`
- `black .`
- `pytest -q`