### PR TITLE
Implement king capture restrictions and checkmate

### DIFF
--- a/src/dh_workspace/core/backend/chessboard.py
+++ b/src/dh_workspace/core/backend/chessboard.py
@@ -30,6 +30,16 @@ class Chessboard:
             [None for _ in range(self.BOARD_WIDTH)] for _ in range(self.BOARD_HEIGHT)
         ]
 
+    def clone(self) -> "Chessboard":
+        """Return a deep copy of this ``Chessboard``."""
+        new_board = Chessboard()
+        for r in range(self.BOARD_HEIGHT):
+            for c in range(self.BOARD_WIDTH):
+                piece = self._board[r][c]
+                if piece is not None:
+                    new_board._board[r][c] = Piece(piece.piece, piece.color)
+        return new_board
+
     def _validate_position(self, row: int, col: int) -> None:
         """Raise ``ValueError`` if ``row`` or ``col`` is outside the board."""
         if not (0 <= row < self.BOARD_HEIGHT and 0 <= col < self.BOARD_WIDTH):

--- a/src/dh_workspace/core/backend/match.py
+++ b/src/dh_workspace/core/backend/match.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from .chessboard import Chessboard, Piece
 from .pieces import (
@@ -12,6 +12,7 @@ from .pieces import (
     Rook,
     King,
     PieceType,
+    PieceColor,
 )
 
 
@@ -24,9 +25,75 @@ class Match:
     current_turn: int = 0
     move_number: int = 1
     captured: List[List[Piece]] = field(default_factory=list)
+    is_completed: bool = False
+
+    _color_order = [
+        PieceColor.WHITE,
+        PieceColor.BLACK,
+        PieceColor.RED,
+        PieceColor.BLUE,
+    ]
 
     def __post_init__(self) -> None:
         self.captured = [[] for _ in range(self.num_players)]
+
+    def _player_color(self, index: int) -> PieceColor:
+        """Return the color associated with ``index``."""
+        return self._color_order[index % len(self._color_order)]
+
+    def _find_king(self, color: PieceColor) -> Optional[Tuple[int, int]]:
+        for r in range(self.board.BOARD_HEIGHT):
+            for c in range(self.board.BOARD_WIDTH):
+                if self.board.get_piece(r, c) == (PieceType.KING, color):
+                    return r, c
+        return None
+
+    def _is_in_check(self, color: PieceColor) -> bool:
+        from .moves import _square_under_attack
+
+        pos = self._find_king(color)
+        if pos is None:
+            return False
+        return _square_under_attack(self.board, color, pos[0], pos[1])
+
+    def _has_escape_moves(self, color: PieceColor) -> bool:
+        from .moves import generate_moves
+
+        if self._find_king(color) is None:
+            return False
+
+        for r in range(self.board.BOARD_HEIGHT):
+            for c in range(self.board.BOARD_WIDTH):
+                piece = self.board.get_piece(r, c)
+                if piece is None:
+                    continue
+                piece_type, p_color = piece
+                if p_color != color:
+                    continue
+                moves = generate_moves(piece_type, self.board, p_color, r, c)
+                for m in moves:
+                    board_copy = self.board.clone()
+                    for cap in m.captures:
+                        board_copy.remove_piece(*cap)
+                    board_copy.remove_piece(r, c)
+                    board_copy.place_piece(m.end[0], m.end[1], piece_type, p_color)
+                    new_pos = (
+                        m.end
+                        if piece_type == PieceType.KING
+                        else self._find_king(color)
+                    )
+                    if new_pos is None:
+                        continue
+                    from .moves import _square_under_attack
+
+                    if not _square_under_attack(
+                        board_copy, color, new_pos[0], new_pos[1]
+                    ):
+                        return True
+        return False
+
+    def _is_checkmate(self, color: PieceColor) -> bool:
+        return self._is_in_check(color) and not self._has_escape_moves(color)
 
     def next_turn(self) -> None:
         """Advance the match to the next player's turn."""
@@ -41,6 +108,8 @@ class Match:
 
     def attempt_move(self, start: Tuple[int, int], end: Tuple[int, int]) -> bool:
         """Attempt to move a piece and update match state."""
+        if self.is_completed:
+            return False
         piece_info = self.board.get_piece(*start)
         if piece_info is None:
             return False
@@ -66,11 +135,20 @@ class Match:
 
         for capture in move.captures:
             captured = self.board.get_piece(*capture)
+            if captured is not None and captured[0] == PieceType.KING:
+                return False
+
+        for capture in move.captures:
+            captured = self.board.get_piece(*capture)
             if captured is not None:
                 self.capture_piece(self.current_turn, Piece(*captured))
                 self.board.remove_piece(*capture)
 
         self.board.remove_piece(*start)
         self.board.place_piece(end[0], end[1], piece_type, color)
-        self.next_turn()
+        opponent_index = (self.current_turn + 1) % self.num_players
+        if self._is_checkmate(self._player_color(opponent_index)):
+            self.is_completed = True
+        else:
+            self.next_turn()
         return True

--- a/src/dh_workspace/core/backend/moves.py
+++ b/src/dh_workspace/core/backend/moves.py
@@ -18,6 +18,10 @@ def _square_under_attack(
     board: "Chessboard", color: PieceColor, row: int, col: int
 ) -> bool:
     """Return ``True`` if ``row`` and ``col`` are threatened by any enemy piece."""
+    original = board.get_piece(row, col)
+    board.remove_piece(row, col)
+    board.place_piece(row, col, PieceType.PAWN, color)
+
     for r in range(board.BOARD_HEIGHT):
         for c in range(board.BOARD_WIDTH):
             piece = board.get_piece(r, c)
@@ -42,7 +46,16 @@ def _square_under_attack(
                 continue
             for move in moves:
                 if move.end == (row, col):
+                    if original is not None:
+                        board.place_piece(row, col, original[0], original[1])
+                    else:
+                        board.remove_piece(row, col)
                     return True
+
+    if original is not None:
+        board.place_piece(row, col, original[0], original[1])
+    else:
+        board.remove_piece(row, col)
     return False
 
 
@@ -77,7 +90,7 @@ def generate_knight_moves(
                 new_col,
             )
             moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
-        elif piece[1] != color:
+        elif piece[1] != color and piece[0] != PieceType.KING:
             logger.debug(
                 "Knight capture from (%s, %s) to (%s, %s)",
                 row,
@@ -111,7 +124,7 @@ def generate_pawn_moves(
 
         piece = board.get_piece(target_row, new_col)
         if is_capture:
-            if piece is not None and piece[1] != color:
+            if piece is not None and piece[1] != color and piece[0] != PieceType.KING:
                 logger.debug(
                     "Pawn capture from (%s, %s) to (%s, %s)",
                     row,
@@ -158,7 +171,7 @@ def generate_bishop_moves(
             if piece is None:
                 moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
             else:
-                if piece[1] != color:
+                if piece[1] != color and piece[0] != PieceType.KING:
                     moves.append(
                         PieceMove(
                             start=(row, col),
@@ -190,7 +203,7 @@ def generate_rook_moves(
             if piece is None:
                 moves.append(PieceMove(start=(row, col), end=(new_row, new_col)))
             else:
-                if piece[1] != color:
+                if piece[1] != color and piece[0] != PieceType.KING:
                     moves.append(
                         PieceMove(
                             start=(row, col),
@@ -237,7 +250,7 @@ def generate_king_moves(
         if not _is_valid(board, new_row, new_col):
             continue
         piece = board.get_piece(new_row, new_col)
-        if piece is None or piece[1] != color:
+        if piece is None or (piece[1] != color and piece[0] != PieceType.KING):
             if safe_moves:
                 if piece is not None and piece[1] != color:
                     board.remove_piece(new_row, new_col)

--- a/tests/backend/test_gameplay.py
+++ b/tests/backend/test_gameplay.py
@@ -61,3 +61,24 @@ def test_starting_position_move_counts() -> None:
             piece_obj = piece_classes[piece_type](color, board)
             moves = piece_obj.possible_moves(row, col)
             assert len(moves) == expected_counts[piece_type]
+
+
+def test_piece_cannot_capture_king() -> None:
+    board = Chessboard()
+    board.place_piece(0, 0, PieceType.KING, PieceColor.BLACK)
+    board.place_piece(0, 2, PieceType.ROOK, PieceColor.WHITE)
+    rook = Rook(PieceColor.WHITE, board)
+    moves = rook.possible_moves(0, 2)
+    assert (0, 0) not in {m.end for m in moves}
+
+
+def test_checkmate_ends_match() -> None:
+    board = Chessboard()
+    board.place_piece(0, 0, PieceType.KING, PieceColor.BLACK)
+    board.place_piece(2, 2, PieceType.KING, PieceColor.WHITE)
+    board.place_piece(1, 2, PieceType.QUEEN, PieceColor.WHITE)
+    match = Match(board, num_players=2)
+
+    assert match.attempt_move((1, 2), (1, 1))
+    assert match.is_completed
+    assert not match.attempt_move((0, 0), (0, 1))


### PR DESCRIPTION
## Summary
- prevent pieces from capturing the enemy king
- add deep copy helper to `Chessboard`
- implement checkmate detection and completion flag in `Match`
- detect attacks on squares without allowing king capture
- add regression tests for king safety and checkmate

## Testing
- `source setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_682f512fd7548324bba8b0b6c8821e53