### PR TITLE
Implement MatchFacade API

### DIFF
--- a/src/dh_workspace/__init__.py
+++ b/src/dh_workspace/__init__.py
@@ -14,6 +14,7 @@ from .core.backend.pieces import (
     PieceColor,
 )
 from .core.backend.match import Match
+from .core.match_facade import MatchFacade
 from .utils.config import CONFIG, Config, configure
 from .utils.logger import logger
 from .frontend.unicode_board import (
@@ -36,6 +37,7 @@ __all__ = [
     "King",
     "PieceType",
     "Match",
+    "MatchFacade",
     "CONFIG",
     "Config",
     "configure",

--- a/src/dh_workspace/core/__init__.py
+++ b/src/dh_workspace/core/__init__.py
@@ -2,6 +2,7 @@
 
 from .backend.chessboard import Chessboard, Piece
 from .backend.match import Match
+from .match_facade import MatchFacade
 from .backend.pieces import ChessPiece, Knight, PieceMove, PieceColor
 from .utils import index_to_letters
 
@@ -13,5 +14,6 @@ __all__ = [
     "PieceColor",
     "Knight",
     "Match",
+    "MatchFacade",
     "index_to_letters",
 ]

--- a/src/dh_workspace/core/match_facade.py
+++ b/src/dh_workspace/core/match_facade.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""High level API for interacting with a chess match."""
+
+from typing import List, Tuple
+
+from .backend.chessboard import Chessboard
+from .backend.match import Match
+from .backend.pieces import (
+    Bishop,
+    King,
+    Knight,
+    Pawn,
+    Queen,
+    Rook,
+    PieceType,
+    PieceMove,
+)
+
+
+class MatchFacade:
+    """Simple facade exposing high level game operations."""
+
+    def __init__(self, num_players: int = 2) -> None:
+        self._num_players = num_players
+        self.reset_game()
+
+    def reset_game(self) -> None:
+        """Reset the board and match to the starting position."""
+        self.board = Chessboard()
+        self.board.reset_board()
+        self.match = Match(self.board, num_players=self._num_players)
+
+    def move_piece(self, start: Tuple[int, int], end: Tuple[int, int]) -> bool:
+        """Move a piece from ``start`` to ``end`` if the move is legal."""
+        return self.match.attempt_move(start, end)
+
+    def get_valid_moves(self, row: int, col: int) -> List[PieceMove]:
+        """Return all legal moves for the piece at ``row`` and ``col``."""
+        piece_info = self.board.get_piece(row, col)
+        if piece_info is None:
+            return []
+
+        piece_type, color = piece_info
+        piece_map = {
+            PieceType.PAWN: Pawn,
+            PieceType.KNIGHT: Knight,
+            PieceType.BISHOP: Bishop,
+            PieceType.ROOK: Rook,
+            PieceType.QUEEN: Queen,
+            PieceType.KING: King,
+        }
+        piece_cls = piece_map[piece_type]
+        piece_obj = piece_cls(color, self.board)
+        return piece_obj.possible_moves(row, col)
+
+    def get_current_turn(self) -> int:
+        """Return the index of the player whose turn it is."""
+        return self.match.current_turn
+
+    def get_move_number(self) -> int:
+        """Return the overall move number in the match."""
+        return self.match.move_number

--- a/tests/backend/test_match_facade.py
+++ b/tests/backend/test_match_facade.py
@@ -1,0 +1,31 @@
+from dh_workspace import MatchFacade, PieceType, PieceColor
+
+
+def test_facade_initial_state_and_move():
+    facade = MatchFacade(num_players=2)
+    assert facade.get_current_turn() == 0
+    assert facade.get_move_number() == 1
+
+    moves = facade.get_valid_moves(6, 0)
+    assert (5, 0) in {m.end for m in moves}
+
+    assert facade.move_piece((6, 0), (5, 0))
+    assert facade.board.get_piece(5, 0) == (PieceType.PAWN, PieceColor.WHITE)
+    assert facade.get_current_turn() == 1
+    assert facade.get_move_number() == 2
+
+
+def test_facade_reset_game():
+    facade = MatchFacade(num_players=2)
+    facade.move_piece((6, 0), (5, 0))
+    assert facade.get_current_turn() == 1
+
+    facade.reset_game()
+    assert facade.board.get_piece(6, 0) == (PieceType.PAWN, PieceColor.WHITE)
+    assert facade.get_current_turn() == 0
+    assert facade.get_move_number() == 1
+
+
+def test_facade_get_valid_moves_empty_square():
+    facade = MatchFacade(num_players=2)
+    assert facade.get_valid_moves(3, 3) == []


### PR DESCRIPTION
## Summary
- add `MatchFacade` to expose a simple API for frontends
- re-export new class from public packages
- test facade behaviour for move, reset and querying valid moves

## Testing
- `source setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6831f198b4e88324833cbadc02237a1f