### PR TITLE
Add robotics spherical point cloud project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ venv/
 
 # macOS
 .DS_Store
+
+# Node projects
+node_modules/
+projects/**/node_modules/
+projects/**/docs/

--- a/README.md
+++ b/README.md
@@ -54,3 +54,36 @@ Refer to `src/projects/chess/README.md` for details about this module.
 
 Following this pattern keeps each prototype isolated while allowing them to
 share tooling and dependencies.
+
+## Robotics – Spherical Point Cloud
+
+The `projects/robotics-spherical-pointcloud` directory contains a standalone
+React + Three.js application that renders an interactive spherical point cloud.
+It is configured for deployment via GitHub Pages using Vite's static output in
+`docs/`.
+
+### Local development
+
+```bash
+cd projects/robotics-spherical-pointcloud
+npm install
+npm run dev
+```
+
+### Tests and production build
+
+```bash
+npm run test
+npm run build
+npm run preview
+```
+
+After building, push the contents of the `docs/` directory to make the site
+available at:
+
+```
+https://<USERNAME>.github.io/dh_workspace/projects/robotics-spherical-pointcloud/
+```
+
+Configure the repository's Pages settings to serve from the `main` branch and
+`/projects/robotics-spherical-pointcloud/docs` folder.

--- a/projects/robotics-spherical-pointcloud/.gitignore
+++ b/projects/robotics-spherical-pointcloud/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+.docs/
+.DS_Store
+.env
+.vscode
+.idea
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+docs/

--- a/projects/robotics-spherical-pointcloud/index.html
+++ b/projects/robotics-spherical-pointcloud/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Robotics – Spherical Point Cloud</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/projects/robotics-spherical-pointcloud/package.json
+++ b/projects/robotics-spherical-pointcloud/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "robotics-spherical-pointcloud",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:ui": "vitest --ui"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.103.0",
+    "@react-three/fiber": "^8.15.13",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.160.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "eslint": "^8.56.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.11",
+    "vitest": "^1.1.3",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/projects/robotics-spherical-pointcloud/src/App.tsx
+++ b/projects/robotics-spherical-pointcloud/src/App.tsx
@@ -1,0 +1,65 @@
+import { Suspense, useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Preload } from '@react-three/drei';
+
+import ControlsPanel from './components/ControlsPanel';
+import PointCloud from './components/PointCloud';
+import { ColorMode, hexToRgb } from './lib/points';
+
+const DEFAULT_SEED = 42;
+const DEFAULT_POINTS = 5000;
+const DEFAULT_RADIUS = 1;
+const DEFAULT_NOISE = 0.02;
+const DEFAULT_COLOR = '#60a5fa';
+
+function App(): JSX.Element {
+  const [seed, setSeed] = useState<number>(DEFAULT_SEED);
+  const [numPoints, setNumPoints] = useState<number>(DEFAULT_POINTS);
+  const [radius, setRadius] = useState<number>(DEFAULT_RADIUS);
+  const [noise, setNoise] = useState<number>(DEFAULT_NOISE);
+  const [colorMode, setColorMode] = useState<ColorMode>('height');
+  const [color, setColor] = useState<string>(DEFAULT_COLOR);
+  const [rotate, setRotate] = useState<boolean>(true);
+
+  const rgbColor = useMemo(() => hexToRgb(color), [color]);
+
+  return (
+    <>
+      <Canvas camera={{ position: [0, 0, 4], fov: 45 }} dpr={[1, 2]}>
+        <color attach="background" args={["#020617"]} />
+        <ambientLight intensity={0.8} />
+        <Suspense fallback={null}>
+          <PointCloud
+            seed={seed}
+            numPoints={numPoints}
+            radius={radius}
+            noise={noise}
+            colorMode={colorMode}
+            color={rgbColor}
+            rotate={rotate}
+          />
+        </Suspense>
+        <OrbitControls enableDamping dampingFactor={0.15} />
+        <Preload all />
+      </Canvas>
+      <ControlsPanel
+        seed={seed}
+        onSeedChange={setSeed}
+        numPoints={numPoints}
+        onNumPointsChange={setNumPoints}
+        radius={radius}
+        onRadiusChange={setRadius}
+        noise={noise}
+        onNoiseChange={setNoise}
+        colorMode={colorMode}
+        onColorModeChange={setColorMode}
+        color={color}
+        onColorChange={setColor}
+        rotate={rotate}
+        onRotateChange={setRotate}
+      />
+    </>
+  );
+}
+
+export default App;

--- a/projects/robotics-spherical-pointcloud/src/components/ControlsPanel.tsx
+++ b/projects/robotics-spherical-pointcloud/src/components/ControlsPanel.tsx
@@ -1,0 +1,139 @@
+import { ChangeEvent } from 'react';
+
+import { ColorMode } from '../lib/points';
+
+interface ControlsPanelProps {
+  seed: number;
+  onSeedChange: (value: number) => void;
+  numPoints: number;
+  onNumPointsChange: (value: number) => void;
+  radius: number;
+  onRadiusChange: (value: number) => void;
+  noise: number;
+  onNoiseChange: (value: number) => void;
+  colorMode: ColorMode;
+  onColorModeChange: (mode: ColorMode) => void;
+  color: string;
+  onColorChange: (value: string) => void;
+  rotate: boolean;
+  onRotateChange: (value: boolean) => void;
+}
+
+const formatNumber = (value: number, fractionDigits = 2): string =>
+  value.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+  });
+
+function ControlsPanel({
+  seed,
+  onSeedChange,
+  numPoints,
+  onNumPointsChange,
+  radius,
+  onRadiusChange,
+  noise,
+  onNoiseChange,
+  colorMode,
+  onColorModeChange,
+  color,
+  onColorChange,
+  rotate,
+  onRotateChange,
+}: ControlsPanelProps): JSX.Element {
+  const handleSeedChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number.parseInt(event.target.value, 10);
+    if (!Number.isNaN(value)) {
+      onSeedChange(value);
+    }
+  };
+
+  return (
+    <section className="controls-panel">
+      <h2>Point Cloud Settings</h2>
+      <label>
+        Seed
+        <input
+          type="number"
+          value={seed}
+          min={0}
+          step={1}
+          onChange={handleSeedChange}
+        />
+      </label>
+      <label>
+        Number of points
+        <div className="range-input">
+          <input
+            type="range"
+            min={1000}
+            max={100000}
+            step={500}
+            value={numPoints}
+            onChange={(event) => onNumPointsChange(Number(event.target.value))}
+          />
+          <span>{numPoints.toLocaleString()}</span>
+        </div>
+      </label>
+      <label>
+        Radius
+        <div className="range-input">
+          <input
+            type="range"
+            min={0.1}
+            max={5}
+            step={0.05}
+            value={radius}
+            onChange={(event) => onRadiusChange(Number(event.target.value))}
+          />
+          <span>{formatNumber(radius)}</span>
+        </div>
+      </label>
+      <label>
+        Noise
+        <div className="range-input">
+          <input
+            type="range"
+            min={0}
+            max={0.2}
+            step={0.005}
+            value={noise}
+            onChange={(event) => onNoiseChange(Number(event.target.value))}
+          />
+          <span>{formatNumber(noise, 3)}</span>
+        </div>
+      </label>
+      <label>
+        Color mode
+        <select
+          value={colorMode}
+          onChange={(event) => onColorModeChange(event.target.value as ColorMode)}
+        >
+          <option value="single">Single</option>
+          <option value="height">Height gradient</option>
+        </select>
+      </label>
+      {colorMode === 'single' ? (
+        <label>
+          Point color
+          <input
+            type="color"
+            value={color}
+            onChange={(event) => onColorChange(event.target.value)}
+            aria-label="Point color picker"
+          />
+        </label>
+      ) : null}
+      <div className="checkbox-row">
+        <input
+          id="rotate-toggle"
+          type="checkbox"
+          checked={rotate}
+          onChange={(event) => onRotateChange(event.target.checked)}
+        />
+        <label htmlFor="rotate-toggle">Auto-rotate</label>
+      </div>
+    </section>
+  );
+}
+
+export default ControlsPanel;

--- a/projects/robotics-spherical-pointcloud/src/components/PointCloud.tsx
+++ b/projects/robotics-spherical-pointcloud/src/components/PointCloud.tsx
@@ -1,0 +1,78 @@
+import { memo, useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+import { ColorMode, RGBColor, generateSpherePoints } from '../lib/points';
+
+interface PointCloudProps {
+  seed: number;
+  numPoints: number;
+  radius: number;
+  noise: number;
+  colorMode: ColorMode;
+  color: RGBColor;
+  rotate: boolean;
+}
+
+function PointCloud({
+  seed,
+  numPoints,
+  radius,
+  noise,
+  colorMode,
+  color,
+  rotate,
+}: PointCloudProps): JSX.Element {
+  const pointsRef = useRef<THREE.Points>(null);
+
+  const { positions, colors } = useMemo(
+    () =>
+      generateSpherePoints({
+        seed,
+        numPoints,
+        radius,
+        noise,
+        colorMode,
+        color,
+      }),
+    [seed, numPoints, radius, noise, colorMode, color],
+  );
+
+  const geometry = useMemo(() => {
+    const bufferGeometry = new THREE.BufferGeometry();
+    bufferGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3),
+    );
+    bufferGeometry.setAttribute(
+      'color',
+      new THREE.BufferAttribute(colors, 3),
+    );
+    bufferGeometry.computeBoundingSphere();
+    return bufferGeometry;
+  }, [positions, colors]);
+
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  useFrame((_, delta) => {
+    if (!rotate) {
+      return;
+    }
+    if (pointsRef.current) {
+      pointsRef.current.rotation.y += delta * 0.25;
+    }
+  });
+
+  return (
+    <points ref={pointsRef} geometry={geometry} frustumCulled={false}>
+      <pointsMaterial
+        size={0.02}
+        vertexColors
+        sizeAttenuation
+        depthWrite={false}
+      />
+    </points>
+  );
+}
+
+export default memo(PointCloud);

--- a/projects/robotics-spherical-pointcloud/src/lib/points.test.ts
+++ b/projects/robotics-spherical-pointcloud/src/lib/points.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateSpherePoints } from './points';
+
+const BASE_CONFIG = {
+  seed: 12345,
+  numPoints: 2048,
+  radius: 1.5,
+  noise: 0,
+  colorMode: 'height' as const,
+};
+
+describe('generateSpherePoints', () => {
+  it('produces deterministic point clouds for the same inputs', () => {
+    const first = generateSpherePoints(BASE_CONFIG);
+    const second = generateSpherePoints(BASE_CONFIG);
+
+    expect(Array.from(second.positions.slice(0, 30))).toStrictEqual(
+      Array.from(first.positions.slice(0, 30)),
+    );
+  });
+
+  it('creates the expected number of coordinates', () => {
+    const { positions } = generateSpherePoints({ ...BASE_CONFIG, numPoints: 4096 });
+    expect(positions.length).toBe(4096 * 3);
+  });
+
+  it('generates points close to the specified radius when noise is zero', () => {
+    const radius = 2.5;
+    const { positions } = generateSpherePoints({ ...BASE_CONFIG, radius });
+    let total = 0;
+    const sampleSize = positions.length / 3;
+    for (let index = 0; index < sampleSize; index += 1) {
+      const offset = index * 3;
+      const x = positions[offset];
+      const y = positions[offset + 1];
+      const z = positions[offset + 2];
+      total += Math.sqrt(x * x + y * y + z * z);
+    }
+    const meanRadius = total / sampleSize;
+    expect(meanRadius).toBeGreaterThan(radius - 0.02);
+    expect(meanRadius).toBeLessThan(radius + 0.02);
+  });
+});

--- a/projects/robotics-spherical-pointcloud/src/lib/points.ts
+++ b/projects/robotics-spherical-pointcloud/src/lib/points.ts
@@ -1,0 +1,141 @@
+import { createNormalGenerator, mulberry32, PRNG } from './prng';
+
+export type ColorMode = 'single' | 'height';
+
+export interface RGBColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface SpherePointOptions {
+  seed: number;
+  numPoints: number;
+  radius: number;
+  noise: number;
+  colorMode: ColorMode;
+  color?: RGBColor;
+}
+
+export interface SpherePointCloud {
+  positions: Float32Array;
+  colors: Float32Array;
+}
+
+const DEFAULT_SINGLE_COLOR: RGBColor = { r: 0.376, g: 0.647, b: 0.996 };
+const BLUE: RGBColor = { r: 0.121, g: 0.305, b: 0.784 };
+const GREEN: RGBColor = { r: 0.102, g: 0.729, b: 0.451 };
+const YELLOW: RGBColor = { r: 0.992, g: 0.871, b: 0.384 };
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+const lerp = (start: number, end: number, t: number): number =>
+  start + (end - start) * t;
+
+const lerpColor = (start: RGBColor, end: RGBColor, t: number): RGBColor => ({
+  r: lerp(start.r, end.r, t),
+  g: lerp(start.g, end.g, t),
+  b: lerp(start.b, end.b, t),
+});
+
+const yGradientColor = (y: number, radius: number): RGBColor => {
+  if (!Number.isFinite(radius) || radius <= 0) {
+    return GREEN;
+  }
+  const normalized = clamp01((y / radius + 1) / 2);
+  if (normalized < 0.5) {
+    return lerpColor(BLUE, GREEN, normalized / 0.5);
+  }
+  return lerpColor(GREEN, YELLOW, (normalized - 0.5) / 0.5);
+};
+
+const colorFromMode = (
+  mode: ColorMode,
+  y: number,
+  radius: number,
+  singleColor: RGBColor,
+): RGBColor => {
+  if (mode === 'height') {
+    return yGradientColor(y, radius);
+  }
+  return singleColor;
+};
+
+const gaussianNoise = (normal: PRNG, amount: number): number => {
+  if (amount <= 0) {
+    return 0;
+  }
+  return normal() * amount;
+};
+
+const directionOnSphere = (prng: PRNG): [number, number, number] => {
+  const u = prng();
+  const v = prng();
+  const theta = 2 * Math.PI * u;
+  const cosPhi = 2 * v - 1;
+  const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
+  const x = sinPhi * Math.cos(theta);
+  const y = cosPhi;
+  const z = sinPhi * Math.sin(theta);
+  return [x, y, z];
+};
+
+export function generateSpherePoints({
+  seed,
+  numPoints,
+  radius,
+  noise,
+  colorMode,
+  color,
+}: SpherePointOptions): SpherePointCloud {
+  const prng = mulberry32(seed);
+  const normal = createNormalGenerator(prng);
+
+  const positions = new Float32Array(numPoints * 3);
+  const colors = new Float32Array(numPoints * 3);
+  const singleColor = color ?? DEFAULT_SINGLE_COLOR;
+
+  for (let index = 0; index < numPoints; index += 1) {
+    const offset = index * 3;
+    const [dirX, dirY, dirZ] = directionOnSphere(prng);
+    const radial = Math.max(0, radius + gaussianNoise(normal, noise));
+
+    positions[offset] = dirX * radial;
+    positions[offset + 1] = dirY * radial;
+    positions[offset + 2] = dirZ * radial;
+
+    const colorValue = colorFromMode(colorMode, positions[offset + 1], radius, singleColor);
+    colors[offset] = colorValue.r;
+    colors[offset + 1] = colorValue.g;
+    colors[offset + 2] = colorValue.b;
+  }
+
+  return { positions, colors };
+}
+
+export function hexToRgb(hex: string): RGBColor {
+  const normalized = hex.replace('#', '').trim();
+  if (normalized.length !== 3 && normalized.length !== 6) {
+    return DEFAULT_SINGLE_COLOR;
+  }
+
+  const expand = normalized.length === 3;
+  const value = expand
+    ? normalized
+        .split('')
+        .map((char) => char + char)
+        .join('')
+    : normalized;
+
+  const r = Number.parseInt(value.slice(0, 2), 16) / 255;
+  const g = Number.parseInt(value.slice(2, 4), 16) / 255;
+  const b = Number.parseInt(value.slice(4, 6), 16) / 255;
+
+  if ([r, g, b].some((component) => Number.isNaN(component))) {
+    return DEFAULT_SINGLE_COLOR;
+  }
+
+  return { r, g, b };
+}
+
+export { DEFAULT_SINGLE_COLOR };

--- a/projects/robotics-spherical-pointcloud/src/lib/prng.test.ts
+++ b/projects/robotics-spherical-pointcloud/src/lib/prng.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { mulberry32 } from './prng';
+
+describe('mulberry32', () => {
+  it('generates repeatable sequences for the same seed', () => {
+    const prngA = mulberry32(9876);
+    const prngB = mulberry32(9876);
+
+    const sequenceA = Array.from({ length: 5 }, () => prngA());
+    const sequenceB = Array.from({ length: 5 }, () => prngB());
+
+    expect(sequenceB).toStrictEqual(sequenceA);
+  });
+});

--- a/projects/robotics-spherical-pointcloud/src/lib/prng.ts
+++ b/projects/robotics-spherical-pointcloud/src/lib/prng.ts
@@ -1,0 +1,51 @@
+export type PRNG = () => number;
+
+const UINT32_MAX = 0xffffffff;
+
+/**
+ * Deterministic pseudo-random number generator based on mulberry32.
+ * @param seed Numeric seed.
+ * @returns Function returning a float in [0, 1).
+ */
+export function mulberry32(seed: number): PRNG {
+  let t = (seed >>> 0) || 0x6d2b79f5;
+  return () => {
+    t += 0x6d2b79f5;
+    let x = Math.imul(t ^ (t >>> 15), t | 1);
+    x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+    return ((x ^ (x >>> 14)) >>> 0) / (UINT32_MAX + 1);
+  };
+}
+
+/**
+ * Returns a PRNG that yields normally distributed values using the Box-Muller
+ * transform.
+ */
+export function createNormalGenerator(prng: PRNG): PRNG {
+  let spare: number | null = null;
+  return () => {
+    if (spare !== null) {
+      const value = spare;
+      spare = null;
+      return value;
+    }
+
+    let u = 0;
+    let v = 0;
+    while (u === 0) {
+      u = prng();
+    }
+    while (v === 0) {
+      v = prng();
+    }
+
+    const mag = Math.sqrt(-2.0 * Math.log(u));
+    const theta = 2.0 * Math.PI * v;
+    spare = mag * Math.sin(theta);
+    return mag * Math.cos(theta);
+  };
+}
+
+export function seededRandom(seed: number): PRNG {
+  return mulberry32(seed);
+}

--- a/projects/robotics-spherical-pointcloud/src/main.tsx
+++ b/projects/robotics-spherical-pointcloud/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/projects/robotics-spherical-pointcloud/src/setupTests.ts
+++ b/projects/robotics-spherical-pointcloud/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/projects/robotics-spherical-pointcloud/src/styles.css
+++ b/projects/robotics-spherical-pointcloud/src/styles.css
@@ -1,0 +1,88 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  color-scheme: dark;
+  background: radial-gradient(circle at top, #0f172a, #020617 70%);
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+}
+
+.controls-panel {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: min(300px, 90vw);
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.9rem;
+}
+
+.controls-panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.controls-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+  font-weight: 500;
+}
+
+.controls-panel input,
+.controls-panel select {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+}
+
+.controls-panel .range-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.controls-panel .range-input input[type='range'] {
+  flex: 1;
+}
+
+.controls-panel .checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+}
+
+@media (max-width: 600px) {
+  .controls-panel {
+    top: auto;
+    bottom: 1rem;
+    right: 50%;
+    transform: translateX(50%);
+  }
+}

--- a/projects/robotics-spherical-pointcloud/src/vite-env.d.ts
+++ b/projects/robotics-spherical-pointcloud/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/projects/robotics-spherical-pointcloud/tsconfig.json
+++ b/projects/robotics-spherical-pointcloud/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/projects/robotics-spherical-pointcloud/tsconfig.node.json
+++ b/projects/robotics-spherical-pointcloud/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/projects/robotics-spherical-pointcloud/vite.config.ts
+++ b/projects/robotics-spherical-pointcloud/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const repoBase = '/dh_workspace/projects/robotics-spherical-pointcloud/';
+
+export default defineConfig({
+  base: repoBase,
+  build: {
+    outDir: 'docs',
+    emptyOutDir: true,
+  },
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite-powered `robotics-spherical-pointcloud` React project configured for GitHub Pages deployment
- implement deterministic spherical point generation utilities, rendering components, and accompanying Vitest coverage
- document the new project workflow and extend the workspace gitignore for Node outputs

## Testing
- source setup.sh
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ca06126dec8324bf0bbcb77ceee447