### PR TITLE
Add static three.js point cloud explorer

### DIFF
--- a/projects/robotics-pointcloud-static/README.md
+++ b/projects/robotics-pointcloud-static/README.md
@@ -1,0 +1,32 @@
+# Robotics Point Cloud (Static)
+
+A lightweight, single-page demo for exploring a spherical point cloud rendered with [three.js](https://threejs.org/). The page is completely static and uses CDN modules so it can be hosted on GitHub Pages without a build step.
+
+## Features
+
+- Seeded, reproducible sampling of points on a noisy sphere
+- Toggle between a uniform colour and a height-based gradient
+- Adjustable point count, sphere radius, gaussian surface noise, and auto-rotation
+- Responsive layout with OrbitControls for intuitive navigation
+
+## Local usage
+
+No tooling is required. Clone the repository and open `projects/robotics-pointcloud-static/index.html` in any modern browser, or serve the directory with a simple static server:
+
+```bash
+python -m http.server --directory projects/robotics-pointcloud-static 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000).
+
+## GitHub Pages
+
+1. Push the repository to GitHub.
+2. In the repository settings, enable GitHub Pages and choose the default branch (usually `main`) as the source. Keep the root (`/`) folder selected.
+3. Your site will be available at:
+
+   ```
+   https://<USER>.github.io/<REPO>/projects/robotics-pointcloud-static/
+   ```
+
+   Replace `<USER>` with your GitHub username and `<REPO>` with the repository name.

--- a/projects/robotics-pointcloud-static/index.html
+++ b/projects/robotics-pointcloud-static/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Robotics Point Cloud Explorer</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="scene-container"></div>
+    <form class="control-panel" id="controls" autocomplete="off">
+      <h1 class="panel-title">Point Cloud</h1>
+      <div class="control-group">
+        <label for="seed">Seed</label>
+        <input type="number" id="seed" name="seed" value="12345" step="1" />
+      </div>
+      <div class="control-group">
+        <label for="numPoints">Points</label>
+        <input
+          type="number"
+          id="numPoints"
+          name="numPoints"
+          min="100"
+          max="100000"
+          step="100"
+          value="5000"
+        />
+      </div>
+      <div class="control-group">
+        <label for="radius">Radius <span class="value-display" data-for="radius">1.00</span></label>
+        <input
+          type="range"
+          id="radius"
+          name="radius"
+          min="0.1"
+          max="5"
+          step="0.05"
+          value="1"
+        />
+      </div>
+      <div class="control-group">
+        <label for="noise">Noise <span class="value-display" data-for="noise">0.02</span></label>
+        <input
+          type="range"
+          id="noise"
+          name="noise"
+          min="0"
+          max="0.2"
+          step="0.002"
+          value="0.02"
+        />
+      </div>
+      <div class="control-group">
+        <label for="colorMode">Color Mode</label>
+        <select id="colorMode" name="colorMode">
+          <option value="single">Single</option>
+          <option value="height">Height</option>
+        </select>
+      </div>
+      <div class="control-group checkbox">
+        <label for="rotate">
+          <input type="checkbox" id="rotate" name="rotate" checked />
+          Auto rotate
+        </label>
+      </div>
+    </form>
+
+    <script type="module">
+      import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+      import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+      import { initPointCloudApp } from './pointcloud.js';
+
+      const defaults = {
+        seed: 12345,
+        numPoints: 5000,
+        radius: 1,
+        noise: 0.02,
+        colorMode: 'single',
+        rotate: true,
+      };
+
+      const container = document.getElementById('scene-container');
+      const controlsForm = document.getElementById('controls');
+      const valueDisplays = Array.from(
+        document.querySelectorAll('[data-for]')
+      );
+
+      const app = initPointCloudApp(container, defaults, { THREE, OrbitControls });
+
+      function clamp(value, min, max) {
+        return Math.min(max, Math.max(min, value));
+      }
+
+      function getParamsFromForm() {
+        const seedValue = Number(document.getElementById('seed').value);
+        const numPointsValue = Number(document.getElementById('numPoints').value);
+        const radiusValue = Number(document.getElementById('radius').value);
+        const noiseValue = Number(document.getElementById('noise').value);
+
+        return {
+          seed: Number.isFinite(seedValue) ? Math.floor(seedValue) : 0,
+          numPoints: Math.floor(
+            clamp(Number.isFinite(numPointsValue) ? numPointsValue : 5000, 100, 100000)
+          ),
+          radius: clamp(radiusValue, 0.1, 5),
+          noise: clamp(noiseValue, 0, 0.2),
+          colorMode: document.getElementById('colorMode').value,
+          rotate: document.getElementById('rotate').checked,
+        };
+      }
+
+      function updateDisplays(params) {
+        valueDisplays.forEach((element) => {
+          if (element.dataset.for === 'radius') {
+            element.textContent = params.radius.toFixed(2);
+          }
+          if (element.dataset.for === 'noise') {
+            element.textContent = params.noise.toFixed(3);
+          }
+        });
+      }
+
+      function updateApp() {
+        const params = getParamsFromForm();
+        updateDisplays(params);
+        app.setParams(params);
+      }
+
+      controlsForm.addEventListener('input', updateApp);
+      controlsForm.addEventListener('change', updateApp);
+
+      document.getElementById('colorMode').value = defaults.colorMode;
+      updateDisplays(defaults);
+      app.setParams(defaults);
+    </script>
+  </body>
+</html>

--- a/projects/robotics-pointcloud-static/pointcloud.js
+++ b/projects/robotics-pointcloud-static/pointcloud.js
@@ -1,0 +1,156 @@
+import { generateSpherePoints } from './utils.js';
+
+const defaultParams = {
+  seed: 12345,
+  numPoints: 5000,
+  radius: 1,
+  noise: 0.02,
+  colorMode: 'single',
+  rotate: true,
+};
+
+let THREERef;
+let OrbitControlsRef;
+let renderer;
+let scene;
+let camera;
+let controls;
+let geometry;
+let material;
+let pointCloud;
+let containerEl;
+let currentParams = { ...defaultParams };
+let animationActive = false;
+
+function ensureDependencies(deps) {
+  if (deps?.THREE) {
+    THREERef = deps.THREE;
+  }
+  if (deps?.OrbitControls) {
+    OrbitControlsRef = deps.OrbitControls;
+  }
+  if (!THREERef || !OrbitControlsRef) {
+    throw new Error('THREE and OrbitControls must be provided.');
+  }
+}
+
+function handleResize() {
+  if (!renderer || !camera || !containerEl) {
+    return;
+  }
+  const width = containerEl.clientWidth || window.innerWidth || 1;
+  const height = containerEl.clientHeight || window.innerHeight || 1;
+  renderer.setSize(width, height);
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+}
+
+function updatePointCloud() {
+  if (!geometry || !material || !THREERef) {
+    return;
+  }
+
+  const { positions, colors, count } = generateSpherePoints({
+    seed: currentParams.seed,
+    n: currentParams.numPoints,
+    R: currentParams.radius,
+    noise: currentParams.noise,
+    colorMode: currentParams.colorMode,
+  });
+
+  geometry.setAttribute(
+    'position',
+    new THREERef.BufferAttribute(positions, 3)
+  );
+  geometry.setAttribute(
+    'color',
+    new THREERef.BufferAttribute(colors, 3, true)
+  );
+  geometry.setDrawRange(0, count);
+  geometry.computeBoundingSphere();
+
+  material.size = Math.max(0.0005, 0.01 * Math.max(currentParams.radius, 0.001));
+  material.needsUpdate = true;
+
+  const targetDistance = Math.max(3 * Math.max(currentParams.radius, 0.1), 3);
+  if (camera) {
+    const currentDistance = camera.position.length();
+    if (Math.abs(currentDistance - targetDistance) > 0.01) {
+      camera.position.set(targetDistance, targetDistance * 0.2, targetDistance);
+    }
+  }
+}
+
+function renderFrame() {
+  if (!renderer || !scene || !camera) {
+    return;
+  }
+  controls?.update();
+  renderer.render(scene, camera);
+}
+
+export function setParams(newParams = {}) {
+  currentParams = { ...currentParams, ...newParams };
+  if (controls) {
+    controls.autoRotate = !!currentParams.rotate;
+  }
+  updatePointCloud();
+}
+
+export function initPointCloudApp(container, initialParams = {}, deps = {}) {
+  if (!container) {
+    throw new Error('A container element is required to initialise the point cloud app.');
+  }
+
+  ensureDependencies(deps);
+  containerEl = container;
+  currentParams = { ...defaultParams, ...initialParams };
+
+  const width = container.clientWidth || window.innerWidth || 1;
+  const height = container.clientHeight || window.innerHeight || 1;
+
+  renderer = new THREERef.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio || 1);
+  renderer.setSize(width, height);
+  renderer.outputColorSpace = THREERef.SRGBColorSpace;
+  container.appendChild(renderer.domElement);
+
+  scene = new THREERef.Scene();
+  scene.background = new THREERef.Color(0x020617);
+
+  camera = new THREERef.PerspectiveCamera(60, width / height, 0.01, 100);
+  const startDistance = Math.max(3 * Math.max(currentParams.radius, 0.1), 3);
+  camera.position.set(startDistance, startDistance * 0.2, startDistance);
+  camera.lookAt(0, 0, 0);
+
+  controls = new OrbitControlsRef(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.autoRotate = !!currentParams.rotate;
+  controls.autoRotateSpeed = 0.4;
+
+  geometry = new THREERef.BufferGeometry();
+  material = new THREERef.PointsMaterial({
+    size: Math.max(0.0005, 0.01 * Math.max(currentParams.radius, 0.001)),
+    sizeAttenuation: true,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.9,
+    depthWrite: false,
+  });
+
+  pointCloud = new THREERef.Points(geometry, material);
+  scene.add(pointCloud);
+
+  updatePointCloud();
+  handleResize();
+
+  if (!animationActive && renderer) {
+    animationActive = true;
+    renderer.setAnimationLoop(renderFrame);
+  }
+
+  window.addEventListener('resize', handleResize);
+
+  return { setParams };
+}

--- a/projects/robotics-pointcloud-static/styles.css
+++ b/projects/robotics-pointcloud-static/styles.css
@@ -1,0 +1,127 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #020617;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+#scene-container {
+  position: fixed;
+  inset: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.control-panel {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 240px;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.85);
+  box-shadow: 0 10px 30px rgba(2, 6, 23, 0.4);
+  backdrop-filter: blur(12px);
+  color: #f8fafc;
+}
+
+.panel-title {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #38bdf8;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.9rem;
+  font-size: 0.85rem;
+}
+
+.control-group:last-of-type {
+  margin-bottom: 0;
+}
+
+.control-group label {
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.control-panel input,
+.control-panel select {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.control-panel input:focus,
+.control-panel select:focus {
+  border-color: #38bdf8;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+}
+
+.control-panel input[type='range'] {
+  padding: 0;
+  accent-color: #38bdf8;
+}
+
+.control-group.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.control-group.checkbox label {
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.control-group.checkbox input[type='checkbox'] {
+  width: auto;
+  height: auto;
+}
+
+.value-display {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+@media (max-width: 600px) {
+  .control-panel {
+    position: static;
+    width: auto;
+    margin: 1rem;
+  }
+
+  #scene-container {
+    position: relative;
+  }
+}

--- a/projects/robotics-pointcloud-static/utils.js
+++ b/projects/robotics-pointcloud-static/utils.js
@@ -1,0 +1,105 @@
+const TAU = Math.PI * 2;
+const SINGLE_COLOR = [0x22, 0xcc, 0xff];
+const HEIGHT_GRADIENT = {
+  low: [34, 102, 255],
+  mid: [34, 197, 94],
+  high: [250, 204, 21],
+};
+
+export function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function rng() {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussianSample(rng) {
+  let u = 0;
+  let v = 0;
+  // Avoid log(0)
+  while (u === 0) {
+    u = rng();
+  }
+  while (v === 0) {
+    v = rng();
+  }
+  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(TAU * v);
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function lerpColor(a, b, t) {
+  return [
+    Math.round(lerp(a[0], b[0], t)),
+    Math.round(lerp(a[1], b[1], t)),
+    Math.round(lerp(a[2], b[2], t)),
+  ];
+}
+
+function computeHeightColor(height, radius) {
+  const span = Math.max(radius, 1e-6);
+  const normalized = (height + span) / (2 * span);
+  const t = Math.min(1, Math.max(0, normalized));
+
+  if (t <= 0.5) {
+    const localT = t / 0.5;
+    return lerpColor(HEIGHT_GRADIENT.low, HEIGHT_GRADIENT.mid, localT);
+  }
+
+  const localT = (t - 0.5) / 0.5;
+  return lerpColor(HEIGHT_GRADIENT.mid, HEIGHT_GRADIENT.high, localT);
+}
+
+export function generateSpherePoints({
+  seed = 0,
+  n = 1,
+  R = 1,
+  noise = 0,
+  colorMode = 'single',
+}) {
+  const count = Math.max(1, Math.floor(n));
+  const radius = Math.max(0, R);
+  const rng = mulberry32(seed);
+  const positions = new Float32Array(count * 3);
+  const colors = new Uint8Array(count * 3);
+
+  for (let i = 0; i < count; i += 1) {
+    const u = rng();
+    const v = rng();
+
+    const theta = TAU * u;
+    const phi = Math.acos(2 * v - 1);
+
+    const sinPhi = Math.sin(phi);
+    const x = Math.cos(theta) * sinPhi;
+    const y = Math.cos(phi);
+    const z = Math.sin(theta) * sinPhi;
+
+    const noiseOffset = noise > 0 ? gaussianSample(rng) * noise : 0;
+    const pointRadius = Math.max(0, radius + noiseOffset);
+
+    const baseIndex = i * 3;
+    positions[baseIndex] = x * pointRadius;
+    positions[baseIndex + 1] = y * pointRadius;
+    positions[baseIndex + 2] = z * pointRadius;
+
+    let color = SINGLE_COLOR;
+    if (colorMode === 'height') {
+      color = computeHeightColor(y * radius, radius);
+    }
+
+    colors[baseIndex] = color[0];
+    colors[baseIndex + 1] = color[1];
+    colors[baseIndex + 2] = color[2];
+  }
+
+  console.assert(positions.length === count * 3, 'Positions length mismatch');
+  console.assert(colors.length === count * 3, 'Colors length mismatch');
+
+  return { positions, colors, count };
+}


### PR DESCRIPTION
## Summary
- build a static robotics point cloud page with a parameter control panel
- implement seeded sphere sampling utilities that feed the three.js renderer
- add styling and documentation for local usage and GitHub Pages deployment

## Testing
- source setup.sh
- black .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca18ca66308324b8334bf0e8372f28