### PR TITLE
Fix OrbitControls CDN import for pointcloud viewer

### DIFF
--- a/projects/robotics-pointcloud-static/index.html
+++ b/projects/robotics-pointcloud-static/index.html
@@ -67,7 +67,7 @@
 
     <script type="module">
       import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-      import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+      import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
       import { initPointCloudApp } from './pointcloud.js';
 
       const defaults = {


### PR DESCRIPTION
## Summary
- add the `?module` query parameter to the OrbitControls CDN import so unpkg resolves its three.js dependency when serving the static page

## Testing
- source setup.sh
- pytest -q
- black .

------
https://chatgpt.com/codex/tasks/task_e_68ca1f7a505083248b0a12ac280ec009