### PR TITLE
Add documentation for reactive store project

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ black .
 
 ## Repository layout
 
-- `src/projects/`: Python packages for each prototype. The current project is
-  available at `src/projects/chess`.
+- `src/projects/`: Python packages for each prototype. Current projects live at
+  `src/projects/chess` and `src/projects/reactive_store`.
 - `src/projects/<name>/tests`: Tests and fixtures that live alongside the
   project code.
 - `src/projects/<name>/README.md`: Optional, project-specific documentation.
@@ -35,10 +35,15 @@ black .
 
 ### Chess project
 
-The existing chess prototype lives at `src/projects/chess`, which now contains
-the implementation, tests, and documentation in a single directory tree.
+The chess prototype lives at `src/projects/chess`, which now contains the
+implementation, tests, and documentation in a single directory tree. Refer to
+`src/projects/chess/README.md` for details about this module.
 
-Refer to `src/projects/chess/README.md` for details about this module.
+### Reactive store project
+
+The reactive in-memory store lives at `src/projects/reactive_store`. It offers a
+hierarchical key-value API that emits events to subscribers whenever keys are
+set or deleted. See `src/projects/reactive_store/README.md` for usage guidance.
 
 ## Adding a new project
 

--- a/src/projects/reactive_store/README.md
+++ b/src/projects/reactive_store/README.md
@@ -1,0 +1,61 @@
+# Reactive Store
+
+A lightweight, thread-safe key-value store that emits change notifications.
+Keys are hierarchical dotted paths (for example `pipeline.stage.step`).
+
+## Creating a store
+
+```python
+from projects.reactive_store import ReactiveStore
+
+store = ReactiveStore()
+```
+
+The store starts a background worker thread to fan out events. Call
+`store.shutdown()` when finished or use it as a context manager to shut down
+automatically.
+
+## Working with data
+
+- `set(path, value)` records a value and emits a `set` event.
+- `get(path)` retrieves the current value or `None` if it is missing.
+- `exists(path)` returns a boolean indicating whether a value is stored.
+- `delete(path)` removes a value. Deleting a missing key is a no-op and does not
+  emit an event.
+- `list(prefix=None)` returns a tuple of paths. With a prefix, only exact
+  matches and descendants are returned.
+
+Paths must be non-empty strings made from letters, numbers, or underscores
+separated by dots. Invalid paths raise `ValueError`.
+
+## Subscriptions
+
+Use `subscribe(selector, callback)` to receive `Event` objects whenever
+matching paths change. A selector can be:
+
+- An exact path such as `"alpha.beta"`.
+- A dotted prefix ending with `.*` to watch descendants, e.g. `"alpha.*"`.
+- A single `*` to receive every event.
+
+Callbacks can be synchronous or `async def`. Async callbacks are awaited in
+the worker thread. The return value is ignored. To stop receiving events, call
+`unsubscribe(subscription_id)`.
+
+`Event` instances include:
+
+- `type`: either `"set"` or `"delete"`.
+- `path`: the full key that changed.
+- `value`: the stored value for `set`, or `None` for `delete`.
+- `version`: a monotonically increasing counter per store.
+- `timestamp`: `time.monotonic()` when the event was created.
+- `origin`: `{"pid": ..., "tid": ...}` showing the producing
+  process/thread.
+
+## Behavior notes
+
+- Callbacks run sequentially inside the worker thread. Exceptions are logged and
+  the event is retried with exponential backoff.
+- Events are delivered in write order. Multiple subscribers can observe the same
+  event.
+- The store is safe to access from multiple threads.
+- Always call `shutdown()` before process exit to flush the internal queue.


### PR DESCRIPTION
## Summary
- add a README for the reactive store detailing its API, subscription options, and behaviors
- update the workspace README to list the reactive store alongside existing projects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e86a799a1c832497038d7e78bb2e08