### PR TITLE
Add Transform3d class for linear algebra utilities

### DIFF
--- a/src/projects/__init__.py
+++ b/src/projects/__init__.py
@@ -1,3 +1,3 @@
 """Namespace package for prototype projects."""
 
-__all__ = ["chess", "reactive_store"]
+__all__ = ["chess", "reactive_store", "linear_algebra"]

--- a/src/projects/linear_algebra/__init__.py
+++ b/src/projects/linear_algebra/__init__.py
@@ -1,0 +1,5 @@
+"""Foundational linear algebra utilities."""
+
+from .transform3d import Transform3d
+
+__all__ = ["Transform3d"]

--- a/src/projects/linear_algebra/tests/test_transform3d.py
+++ b/src/projects/linear_algebra/tests/test_transform3d.py
@@ -1,0 +1,100 @@
+"""Tests for the :mod:`projects.linear_algebra.transform3d` module."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from projects.linear_algebra import Transform3d
+
+
+def rotation_matrix_x(angle_deg: float) -> np.ndarray:
+    angle = np.deg2rad(angle_deg)
+    c, s = np.cos(angle), np.sin(angle)
+    return np.array([[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]])
+
+
+def rotation_matrix_y(angle_deg: float) -> np.ndarray:
+    angle = np.deg2rad(angle_deg)
+    c, s = np.cos(angle), np.sin(angle)
+    return np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+
+def rotation_matrix_z(angle_deg: float) -> np.ndarray:
+    angle = np.deg2rad(angle_deg)
+    c, s = np.cos(angle), np.sin(angle)
+    return np.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+
+def axis_angle_quaternion(axis: np.ndarray, angle_deg: float) -> np.ndarray:
+    axis = np.asarray(axis, dtype=float)
+    axis = axis / np.linalg.norm(axis)
+    angle = np.deg2rad(angle_deg)
+    half_angle = angle / 2.0
+    sin_half = np.sin(half_angle)
+    return np.concatenate((axis * sin_half, [np.cos(half_angle)]))
+
+
+def test_identity_does_not_modify_points() -> None:
+    transform = Transform3d.identity()
+    point = np.array([1.0, -2.0, 3.0])
+    assert_allclose(transform.apply(point), point)
+
+    cloud = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]])
+    assert_allclose(transform.apply(cloud), cloud)
+
+
+def test_as_matrix_and_from_matrix_roundtrip() -> None:
+    rotation = rotation_matrix_z(25.0) @ rotation_matrix_x(-10.0)
+    translation = np.array([3.0, -4.0, 5.0])
+    transform = Transform3d.from_translation_rotation(translation, rotation)
+
+    matrix = transform.as_matrix()
+    rebuilt = Transform3d.from_matrix(matrix)
+
+    assert_allclose(rebuilt.translation, translation)
+    assert_allclose(rebuilt.rotation_matrix, rotation, atol=1e-12)
+
+
+def test_compose_matches_matrix_product() -> None:
+    base = Transform3d.from_translation_rotation(
+        [1.0, 0.0, 0.0], rotation_matrix_z(90.0)
+    )
+    offset = Transform3d.from_translation_rotation(
+        [0.0, 1.0, 0.0], rotation_matrix_x(45.0)
+    )
+
+    composed = base.compose(offset)
+
+    matrix_product = base.as_matrix() @ offset.as_matrix()
+    expected = Transform3d.from_matrix(matrix_product)
+
+    assert_allclose(composed.translation, expected.translation)
+    assert_allclose(composed.rotation_matrix, expected.rotation_matrix, atol=1e-12)
+
+
+def test_inverse_recovers_identity() -> None:
+    quaternion = axis_angle_quaternion(np.array([1.0, 2.0, 3.0]), 67.0)
+    transform = Transform3d.from_translation_rotation([-3.0, 2.0, 5.0], quaternion)
+
+    identity = transform.compose(transform.inverse())
+    assert_allclose(identity.translation, np.zeros(3), atol=1e-12)
+    assert_allclose(identity.rotation_matrix, np.eye(3), atol=1e-12)
+
+
+def test_quaternion_matches_rotation() -> None:
+    quaternion = axis_angle_quaternion(np.array([0.0, 0.0, 1.0]), 90.0)
+    transform = Transform3d.from_translation_rotation([0.0, 0.0, 0.0], quaternion)
+
+    assert_allclose(transform.quaternion, quaternion)
+
+
+def test_translate_and_rotate_helpers() -> None:
+    transform = Transform3d.identity()
+    translated = transform.translate([1.0, 2.0, 3.0])
+    assert_allclose(translated.translation, np.array([1.0, 2.0, 3.0]))
+
+    quarter_turn = axis_angle_quaternion(np.array([0.0, 1.0, 0.0]), 90.0)
+    rotated = transform.rotate(quarter_turn)
+    expected_matrix = rotation_matrix_y(90.0)
+    assert_allclose(rotated.rotation_matrix, expected_matrix, atol=1e-12)

--- a/src/projects/linear_algebra/transform3d.py
+++ b/src/projects/linear_algebra/transform3d.py
@@ -1,0 +1,211 @@
+"""Three-dimensional rigid transformation utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+Vector3 = NDArray[np.float64]
+Quaternion = NDArray[np.float64]
+Matrix3 = NDArray[np.float64]
+Matrix4 = NDArray[np.float64]
+
+
+def _normalize_quaternion(quaternion: ArrayLike) -> Quaternion:
+    """Return a unit quaternion from any four-vector."""
+    quat = np.asarray(quaternion, dtype=float).reshape(-1)
+    if quat.shape != (4,):
+        raise ValueError("Quaternion must be a four-element vector.")
+
+    norm = np.linalg.norm(quat)
+    if norm == 0:
+        raise ValueError("Quaternion must have a non-zero magnitude.")
+    return quat / norm
+
+
+def _quaternion_from_matrix(matrix: ArrayLike) -> Quaternion:
+    """Convert a 3x3 rotation matrix into a quaternion."""
+    mat = np.asarray(matrix, dtype=float)
+    if mat.shape != (3, 3):
+        raise ValueError("Rotation matrix must have shape (3, 3).")
+
+    trace = np.trace(mat)
+    if trace > 0.0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (mat[2, 1] - mat[1, 2]) * s
+        y = (mat[0, 2] - mat[2, 0]) * s
+        z = (mat[1, 0] - mat[0, 1]) * s
+    else:
+        diag = np.array([mat[0, 0], mat[1, 1], mat[2, 2]])
+        idx = int(np.argmax(diag))
+        if idx == 0:
+            s = 2.0 * np.sqrt(1.0 + mat[0, 0] - mat[1, 1] - mat[2, 2])
+            x = 0.25 * s
+            y = (mat[0, 1] + mat[1, 0]) / s
+            z = (mat[0, 2] + mat[2, 0]) / s
+            w = (mat[2, 1] - mat[1, 2]) / s
+        elif idx == 1:
+            s = 2.0 * np.sqrt(1.0 + mat[1, 1] - mat[0, 0] - mat[2, 2])
+            x = (mat[0, 1] + mat[1, 0]) / s
+            y = 0.25 * s
+            z = (mat[1, 2] + mat[2, 1]) / s
+            w = (mat[0, 2] - mat[2, 0]) / s
+        else:
+            s = 2.0 * np.sqrt(1.0 + mat[2, 2] - mat[0, 0] - mat[1, 1])
+            x = (mat[0, 2] + mat[2, 0]) / s
+            y = (mat[1, 2] + mat[2, 1]) / s
+            z = 0.25 * s
+            w = (mat[1, 0] - mat[0, 1]) / s
+    return _normalize_quaternion(np.array([x, y, z, w]))
+
+
+def _matrix_from_quaternion(quaternion: Quaternion) -> Matrix3:
+    """Return the rotation matrix associated with ``quaternion``."""
+    x, y, z, w = quaternion
+    xx, yy, zz = x * x, y * y, z * z
+    xy, xz, yz = x * y, x * z, y * z
+    xw, yw, zw = x * w, y * w, z * w
+
+    return np.array(
+        [
+            [1.0 - 2.0 * (yy + zz), 2.0 * (xy - zw), 2.0 * (xz + yw)],
+            [2.0 * (xy + zw), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - xw)],
+            [2.0 * (xz - yw), 2.0 * (yz + xw), 1.0 - 2.0 * (xx + yy)],
+        ]
+    )
+
+
+def _quaternion_multiply(lhs: Quaternion, rhs: Quaternion) -> Quaternion:
+    """Return the Hamilton product ``lhs * rhs``."""
+    x1, y1, z1, w1 = lhs
+    x2, y2, z2, w2 = rhs
+    x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+    y = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
+    z = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
+    w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+    return _normalize_quaternion(np.array([x, y, z, w]))
+
+
+def _quaternion_conjugate(quaternion: Quaternion) -> Quaternion:
+    """Return the conjugate of ``quaternion``."""
+    x, y, z, w = quaternion
+    return np.array([-x, -y, -z, w])
+
+
+def _coerce_quaternion(rotation: ArrayLike) -> Quaternion:
+    """Parse supported rotation formats into a quaternion."""
+    rotation_arr = np.asarray(rotation, dtype=float)
+    if rotation_arr.shape == (4,):
+        return _normalize_quaternion(rotation_arr)
+    if rotation_arr.shape == (3, 3):
+        return _quaternion_from_matrix(rotation_arr)
+    raise TypeError("Rotation must be provided as a quaternion or 3x3 rotation matrix.")
+
+
+class Transform3d:
+    """Represents a 3D rigid transform with rotation and translation."""
+
+    __slots__ = ("_translation", "_quaternion")
+
+    def __init__(self, translation: ArrayLike, rotation: ArrayLike) -> None:
+        translation_arr = np.asarray(translation, dtype=float).reshape(-1)
+        if translation_arr.shape != (3,):
+            raise ValueError("Translation must be a three-dimensional vector.")
+        self._translation = translation_arr
+        self._quaternion = _coerce_quaternion(rotation)
+
+    @property
+    def translation(self) -> Vector3:
+        """Return the translation component."""
+        return self._translation.copy()
+
+    @property
+    def quaternion(self) -> Quaternion:
+        """Return the rotation encoded as ``[x, y, z, w]``."""
+        return self._quaternion.copy()
+
+    @property
+    def rotation_matrix(self) -> Matrix3:
+        """Return the 3x3 rotation matrix."""
+        return _matrix_from_quaternion(self._quaternion)
+
+    @classmethod
+    def identity(cls) -> "Transform3d":
+        """Return the identity transform."""
+        return cls(translation=np.zeros(3), rotation=np.array([0.0, 0.0, 0.0, 1.0]))
+
+    @classmethod
+    def from_translation_rotation(
+        cls, translation: ArrayLike, rotation: ArrayLike
+    ) -> "Transform3d":
+        """Construct a transform from translation and rotation components."""
+        return cls(translation=translation, rotation=rotation)
+
+    @classmethod
+    def from_matrix(cls, matrix: ArrayLike) -> "Transform3d":
+        """Build a transform from a 4x4 homogeneous transformation matrix."""
+        mat = np.asarray(matrix, dtype=float)
+        if mat.shape != (4, 4):
+            raise ValueError("Matrix must have shape (4, 4).")
+        rotation = mat[:3, :3]
+        translation = mat[:3, 3]
+        return cls(translation=translation, rotation=rotation)
+
+    def as_matrix(self) -> Matrix4:
+        """Return the 4x4 homogeneous transformation matrix."""
+        matrix = np.eye(4)
+        matrix[:3, :3] = self.rotation_matrix
+        matrix[:3, 3] = self._translation
+        return matrix
+
+    def apply(self, points: ArrayLike) -> NDArray[np.float64]:
+        """Apply the transform to a single point or an array of points."""
+        pts = np.asarray(points, dtype=float)
+        rot_matrix = self.rotation_matrix
+        if pts.ndim == 1:
+            if pts.shape != (3,):
+                raise ValueError("Point must have shape (3,).")
+            return rot_matrix @ pts + self._translation
+        if pts.ndim == 2 and pts.shape[1] == 3:
+            return pts @ rot_matrix.T + self._translation
+        raise ValueError("Points must be a 3-vector or array with shape (N, 3).")
+
+    def compose(self, other: "Transform3d") -> "Transform3d":
+        """Return the transform equivalent to applying ``other`` then ``self``."""
+        composed_quaternion = _quaternion_multiply(self._quaternion, other._quaternion)
+        composed_translation = (
+            self.rotation_matrix @ other._translation + self._translation
+        )
+        return Transform3d(
+            translation=composed_translation, rotation=composed_quaternion
+        )
+
+    def inverse(self) -> "Transform3d":
+        """Return the inverse transformation."""
+        inv_quaternion = _quaternion_conjugate(self._quaternion)
+        inv_rotation = _matrix_from_quaternion(inv_quaternion)
+        inv_translation = -inv_rotation @ self._translation
+        return Transform3d(translation=inv_translation, rotation=inv_quaternion)
+
+    def translate(self, offset: ArrayLike) -> "Transform3d":
+        """Return a copy with an additional translation applied."""
+        offset_vec = np.asarray(offset, dtype=float).reshape(-1)
+        if offset_vec.shape != (3,):
+            raise ValueError("Offset must be a three-dimensional vector.")
+        return Transform3d(
+            translation=self._translation + offset_vec,
+            rotation=self._quaternion,
+        )
+
+    def rotate(self, rotation: ArrayLike) -> "Transform3d":
+        """Return a copy rotated by the provided quaternion or matrix."""
+        rot_quaternion = _coerce_quaternion(rotation)
+        combined = _quaternion_multiply(rot_quaternion, self._quaternion)
+        return Transform3d(translation=self._translation, rotation=combined)
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly representation."""
+        translation = np.array2string(self._translation, precision=5)
+        quaternion = np.array2string(self._quaternion, precision=5)
+        return f"Transform3d(translation={translation}, quaternion={quaternion})"


### PR DESCRIPTION
## Summary
- create a new `linear_algebra` project namespace that exposes a `Transform3d` helper
- implement a quaternion-backed `Transform3d` class with matrix conversion, composition, inverse, and helper operations
- add unit tests covering matrix/quaternion conversions and transform composition behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e86cae0acc8324b86887e9f48c5ba4