### PR TITLE
Document linear algebra utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ black .
 ## Repository layout
 
 - `src/projects/`: Python packages for each prototype. Current projects live at
-  `src/projects/chess` and `src/projects/reactive_store`.
+  `src/projects/chess`, `src/projects/linear_algebra`, and
+  `src/projects/reactive_store`.
 - `src/projects/<name>/tests`: Tests and fixtures that live alongside the
   project code.
 - `src/projects/<name>/README.md`: Optional, project-specific documentation.
@@ -44,6 +45,14 @@ implementation, tests, and documentation in a single directory tree. Refer to
 The reactive in-memory store lives at `src/projects/reactive_store`. It offers a
 hierarchical key-value API that emits events to subscribers whenever keys are
 set or deleted. See `src/projects/reactive_store/README.md` for usage guidance.
+
+### Linear algebra project
+
+The linear algebra utilities live at `src/projects/linear_algebra`. It currently
+focuses on 3D rigid-body math and provides the `Transform3d` class for applying,
+composing, and inverting transformations represented by translation vectors and
+quaternions. Explore `src/projects/linear_algebra/README.md` for background and
+examples.
 
 ## Adding a new project
 

--- a/src/projects/linear_algebra/README.md
+++ b/src/projects/linear_algebra/README.md
@@ -1,0 +1,46 @@
+# Linear algebra utilities
+
+This package contains helpers for working with three-dimensional rigid-body
+transformations. The core component is the `Transform3d` class defined in
+`transform3d.py`, which encapsulates rotation (as a quaternion or rotation
+matrix) and translation vectors in a single object.
+
+## Features
+
+- Parse rotations provided as quaternions or 3x3 rotation matrices.
+- Generate homogeneous 4x4 matrices from a transform instance.
+- Apply transforms to single points or batches of 3D points.
+- Compose multiple transforms using quaternion multiplication.
+- Compute inverse transforms for undoing a rigid-body pose.
+
+## Usage
+
+```python
+import numpy as np
+from projects.linear_algebra.transform3d import Transform3d
+
+base_pose = Transform3d.from_translation_rotation(
+    translation=[1.0, 2.0, 3.0],
+    rotation=[0.0, 0.0, 0.0, 1.0],  # identity quaternion
+)
+
+# Apply the transform to a point in space
+point = np.array([0.5, -0.25, 1.0])
+world_point = base_pose.apply(point)
+
+# Compose with an additional rotation around Z
+rotation = Transform3d.from_translation_rotation(
+    translation=[0.0, 0.0, 0.0],
+    rotation=[0.0, 0.0, np.sin(np.pi / 4), np.cos(np.pi / 4)],
+)
+combined = rotation.compose(base_pose)
+
+# Convert back to a 4x4 homogeneous matrix
+matrix = combined.as_matrix()
+```
+
+Run the project's tests from the repository root with:
+
+```bash
+pytest src/projects/linear_algebra/tests
+```


### PR DESCRIPTION
## Summary
- list the linear algebra utilities alongside existing projects in the main README
- add documentation and usage examples for the Transform3d helper in a project README

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e87b2abddc8324bcbcead4322fec07