### PR TITLE
Add transform interpolation helper and tests

### DIFF
--- a/src/projects/linear_algebra/__init__.py
+++ b/src/projects/linear_algebra/__init__.py
@@ -1,5 +1,5 @@
 """Foundational linear algebra utilities."""
 
-from .transform3d import Transform3d
+from .transform3d import Transform3d, interpolate_transform
 
-__all__ = ["Transform3d"]
+__all__ = ["Transform3d", "interpolate_transform"]


### PR DESCRIPTION
## Summary
- add an interpolate_transform utility that blends translations and performs quaternion slerp
- expose the helper through the linear_algebra package API
- add unit tests covering interpolation behavior and invalid fractions

## Testing
- source setup.sh && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e87b95d5b483248a6d545619f39c1d